### PR TITLE
Fix circle error and tweak makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+bin
 dockcross
+*/test/

--- a/Makefile
+++ b/Makefile
@@ -1,45 +1,95 @@
 DOCKER = docker
 ORG = dockcross
+BIN = bin
 
-all: base android-arm linux-x86 linux-x64 linux-arm64 linux-armv5 linux-armv6 linux-armv7 windows-x86 windows-x64
+images: base android-arm linux-x86 linux-x64 linux-arm64 linux-armv5 linux-armv6 linux-armv7 windows-x86 windows-x64
 
+tests: base.test android-arm.test linux-x86.test linux-x64.test linux-arm64.test linux-armv5.test linux-armv6.test linux-armv7.test windows-x86.test windows-x64.test
 
 android-arm: base android-arm/Dockerfile
 	$(DOCKER) build -t $(ORG)/android-arm android-arm
+
+android-arm.test: android-arm test/run.py
+	$(DOCKER) run --rm dockcross/android-arm > $(BIN)/dockcross-android-arm && chmod +x $(BIN)/dockcross-android-arm
+	$(BIN)/dockcross-android-arm python test/run.py
 
 browser-asmjs: base browser-asmjs/Dockerfile
 	cp -r test browser-asmjs/
 	$(DOCKER) build -t $(ORG)/browser-asmjs browser-asmjs
 	rm -rf browser-asmjs/test
 
+browser-asmjs.test: browser-asmjs test/run.py
+	$(DOCKER) run --rm dockcross/browser-asmjs > $(BIN)/dockcross-browser-asmjs && chmod +x $(BIN)/dockcross-browser-asmjs
+	$(BIN)/dockcross-browser-asmjs python test/run.py --emulator /usr/bin/node --exe-suffix ".js"
+
 linux-x86: base linux-x86/Dockerfile linux-x86/Toolchain.cmake
 	$(DOCKER) build -t $(ORG)/linux-x86 linux-x86
+
+linux-x86.test: linux-x86 test/run.py
+	$(DOCKER) run --rm dockcross/linux-x86 > $(BIN)/dockcross-linux-x86 && chmod +x $(BIN)/dockcross-linux-x86
+	$(BIN)/dockcross-linux-x86 python test/run.py
 
 linux-x64: base linux-x64/Dockerfile
 	$(DOCKER) build -t $(ORG)/linux-x64 linux-x64
 
+linux-x64.test: linux-x64 test/run.py
+	$(DOCKER) run --rm dockcross/linux-x64 > $(BIN)/dockcross-linux-x64 && chmod +x $(BIN)/dockcross-linux-x64
+	$(BIN)/dockcross-linux-x64 python test/run.py
+
 linux-arm64: base linux-arm64/Dockerfile linux-arm64/Toolchain.cmake
 	$(DOCKER) build -t $(ORG)/linux-arm64 linux-arm64
+
+linux-arm64.test: linux-arm64 test/run.py
+	$(DOCKER) run --rm dockcross/linux-arm64 > $(BIN)/dockcross-linux-arm64 && chmod +x $(BIN)/dockcross-linux-arm64
+	$(BIN)/dockcross-linux-arm64 python test/run.py --emulator /usr/bin/qemu-aarch64
 
 linux-armv5: base linux-armv5/Dockerfile linux-armv5/Toolchain.cmake
 	$(DOCKER) build -t $(ORG)/linux-armv5 linux-armv5
 
+linux-armv5.test: linux-armv5 test/run.py
+	$(DOCKER) run --rm dockcross/linux-armv5 > $(BIN)/dockcross-linux-armv5 && chmod +x $(BIN)/dockcross-linux-armv5
+	$(BIN)/dockcross-linux-armv5 python test/run.py --emulator /usr/bin/qemu-arm
+
 linux-armv6: base linux-armv6/Dockerfile linux-armv6/Toolchain.cmake
 	$(DOCKER) build -t $(ORG)/linux-armv6 linux-armv6
+
+linux-armv6.test: linux-armv6 test/run.py
+	$(DOCKER) run --rm dockcross/linux-armv6 > $(BIN)/dockcross-linux-armv6 && chmod +x $(BIN)/dockcross-linux-armv6
+	$(BIN)/dockcross-linux-armv6 python test/run.py --emulator /usr/bin/qemu-arm
 
 linux-armv7: base linux-armv7/Dockerfile linux-armv7/Toolchain.cmake
 	$(DOCKER) build -t $(ORG)/linux-armv7 linux-armv7
 
+linux-armv7.test: linux-armv7 test/run.py
+	$(DOCKER) run --rm dockcross/linux-armv7 > $(BIN)/dockcross-linux-armv7 && chmod +x $(BIN)/dockcross-linux-armv7
+	$(BIN)/dockcross-linux-armv7 python test/run.py --emulator /usr/bin/qemu-arm
+
 linux-ppc64le: base linux-ppc64le/Dockerfile linux-ppc64le/Toolchain.cmake
 	$(DOCKER) build -t $(ORG)/linux-ppc64le linux-ppc64le
+
+linux-ppc64le.test: linux-ppc64le test/run.py
+	$(DOCKER) run --rm dockcross/linux-ppc64le > $(BIN)/dockcross-linux-ppc64le && chmod +x $(BIN)/dockcross-linux-ppc64le
+	$(BIN)/dockcross-linux-ppc64le python test/run.py --emulator /usr/bin/qemu-ppc64le --languages C
 
 windows-x86: base windows-x86/Dockerfile windows-x86/settings.mk
 	$(DOCKER) build -t $(ORG)/windows-x86 windows-x86
 
+windows-x86.test: windows-x86 test/run.py
+	$(DOCKER) run --rm dockcross/windows-x86 > $(BIN)/dockcross-windows-x86 && chmod +x $(BIN)/dockcross-windows-x86
+	$(BIN)/dockcross-windows-x86 python test/run.py --emulator /usr/bin/wine --exe-suffix ".exe"
+
 windows-x64: base windows-x64/Dockerfile windows-x64/settings.mk
 	$(DOCKER) build -t $(ORG)/windows-x64 windows-x64
+
+windows-x64.test: windows-x64 test/run.py
+	$(DOCKER) run --rm dockcross/windows-x64 > $(BIN)/dockcross-windows-x64 && chmod +x $(BIN)/dockcross-windows-x64
+	$(BIN)/dockcross-windows-x64 python test/run.py --emulator /usr/bin/wine --exe-suffix ".exe"
 
 base: Dockerfile
 	$(DOCKER) build -t $(ORG)/base .
 
-.PHONY: default all base android-arm darwin-x64 linux-x86 linux-x64 linux-arm64 linux-armv5 linux-armv6 linux-armv7 windows-x86 windows-x64
+base.test: base test/run.py
+	$(DOCKER) run --rm dockcross/base > $(BIN)/dockcross-base && chmod +x $(BIN)/dockcross-base
+	$(BIN)/dockcross-base python test/run.py --emulator 'sh -c'
+
+.PHONY: images base android-arm linux-x86 linux-x64 linux-arm64 linux-armv5 linux-armv6 linux-armv7 windows-x86 windows-x64 tests %.test

--- a/circle.yml
+++ b/circle.yml
@@ -35,7 +35,7 @@ test:
     - ./dockcross-browser-asmjs python test/run.py --emulator /usr/bin/node --exe-suffix ".js"
     - make linux-arm64
     - docker run --rm dockcross/linux-arm64 > ./dockcross-linux-arm64 && chmod +x ./dockcross-linux-arm64
-    - ./dockcross-linux-arm64 python test/run.py --emulator /usr/bin/qemu-arm
+    - ./dockcross-linux-arm64 python test/run.py --emulator /usr/bin/qemu-aarch64
     - make linux-armv5
     - docker run --rm dockcross/linux-armv5 > ./dockcross-linux-armv5 && chmod +x ./dockcross-linux-armv5
     - ./dockcross-linux-armv5 python test/run.py --emulator /usr/bin/qemu-arm

--- a/circle.yml
+++ b/circle.yml
@@ -45,7 +45,6 @@ test:
     - make linux-armv7
     - docker run --rm dockcross/linux-armv7 > ./dockcross-linux-armv7 && chmod +x ./dockcross-linux-armv7
     - ./dockcross-linux-armv7 python test/run.py --emulator /usr/bin/qemu-arm
-    - ./dockcross-linux-armv7 && chmod +x ./dockcross-linux-armv7 && ./dockcross-linux-armv7 bash -c '$CC test/C/hello.c -o hello_arm'
     - make linux-ppc64le
     - docker run --rm dockcross/linux-ppc64le > ./dockcross-linux-ppc64le && chmod +x ./dockcross-linux-ppc64le
     - ./dockcross-linux-ppc64le python test/run.py --emulator /usr/bin/qemu-ppc64le --languages C

--- a/circle.yml
+++ b/circle.yml
@@ -24,44 +24,20 @@ dependencies:
 
 test:
   override:
-    - make base
-    - docker run --rm dockcross/base > ./dockcross-base && chmod +x ./dockcross-base
-    - ./dockcross-base python test/run.py --emulator 'sh -c'
-    - make android-arm
-    - docker run --rm dockcross/android-arm > ./dockcross-android-arm && chmod +x ./dockcross-android-arm
-    - ./dockcross-android-arm python test/run.py
-    - make browser-asmjs
-    - docker run --rm dockcross/browser-asmjs > ./dockcross-browser-asmjs && chmod +x ./dockcross-browser-asmjs
-    - ./dockcross-browser-asmjs python test/run.py --emulator /usr/bin/node --exe-suffix ".js"
-    - make linux-arm64
-    - docker run --rm dockcross/linux-arm64 > ./dockcross-linux-arm64 && chmod +x ./dockcross-linux-arm64
-    - ./dockcross-linux-arm64 python test/run.py --emulator /usr/bin/qemu-aarch64
-    - make linux-armv5
-    - docker run --rm dockcross/linux-armv5 > ./dockcross-linux-armv5 && chmod +x ./dockcross-linux-armv5
-    - ./dockcross-linux-armv5 python test/run.py --emulator /usr/bin/qemu-arm
-    - make linux-armv6
-    - docker run --rm dockcross/linux-armv6 > ./dockcross-linux-armv6 && chmod +x ./dockcross-linux-armv6
-    - ./dockcross-linux-armv6 python test/run.py --emulator /usr/bin/qemu-arm
-    - make linux-armv7
-    - docker run --rm dockcross/linux-armv7 > ./dockcross-linux-armv7 && chmod +x ./dockcross-linux-armv7
-    - ./dockcross-linux-armv7 python test/run.py --emulator /usr/bin/qemu-arm
-    - make linux-ppc64le
-    - docker run --rm dockcross/linux-ppc64le > ./dockcross-linux-ppc64le && chmod +x ./dockcross-linux-ppc64le
-    - ./dockcross-linux-ppc64le python test/run.py --emulator /usr/bin/qemu-ppc64le --languages C
-    - make linux-x64
-    - docker run --rm dockcross/linux-x64 > ./dockcross-linux-x64 && chmod +x ./dockcross-linux-x64
-    - ./dockcross-linux-x64 python test/run.py
-    - make linux-x86
-    - docker run --rm dockcross/linux-x86 > ./dockcross-linux-x86 && chmod +x ./dockcross-linux-x86
-    - ./dockcross-linux-x86 python test/run.py
-    - make windows-x64:
+    - make base/test
+    - make android-arm/test
+    - make browser-asmjs/test
+    - make linux-arm64/test
+    - make linux-armv5/test
+    - make linux-armv6/test
+    - make linux-armv7/test
+    - make linux-ppc64le/test
+    - make linux-x64/test
+    - make linux-x86/test
+    - make windows-x64/test:
         timeout: 3000
-    - docker run --rm dockcross/windows-x64 > ./dockcross-windows-x64 && chmod +x ./dockcross-windows-x64
-    - ./dockcross-windows-x64 python test/run.py --emulator /usr/bin/wine --exe-suffix ".exe"
-    - make windows-x86:
+    - make windows-x86/test:
         timeout: 3000
-    - docker run --rm dockcross/windows-x86 > ./dockcross-windows-x86 && chmod +x ./dockcross-windows-x86
-    - ./dockcross-windows-x86 python test/run.py --emulator /usr/bin/wine --exe-suffix ".exe"
 
 deployment:
   hub:


### PR DESCRIPTION
In addition to the existing targets:

```
make android-arm
make browser-asmjs
...
```

there are now 

```
make android-arm.test
make browser-asmjs.test
...
```

and also 

```
make tests
```