### PR TITLE
Manylinux allow pip install

### DIFF
--- a/imagefiles/entrypoint.sh
+++ b/imagefiles/entrypoint.sh
@@ -25,14 +25,11 @@ if [[ -n $BUILDER_UID ]] && [[ -n $BUILDER_GID ]]; then
 
     groupadd -o -g $BUILDER_GID $BUILDER_GROUP 2> /dev/null
     useradd -o -m -g $BUILDER_GID -u $BUILDER_UID $BUILDER_USER 2> /dev/null
+    echo "$BUILDER_USER    ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
     export HOME=/home/${BUILDER_USER}
     shopt -s dotglob
     cp -r /root/* $HOME/
     chown -R $BUILDER_UID:$BUILDER_GID $HOME/*
-
-    if [[ -e "${DOCKCROSS_ENTRYPOINT_PRE_EXEC_SCRIPT}" ]]; then
-        ${DOCKCROSS_ENTRYPOINT_PRE_EXEC_SCRIPT}
-    fi
 
     # Run the command as the specified user/group.
     exec chpst -u :$BUILDER_UID:$BUILDER_GID "$@"

--- a/imagefiles/entrypoint.sh
+++ b/imagefiles/entrypoint.sh
@@ -30,6 +30,10 @@ if [[ -n $BUILDER_UID ]] && [[ -n $BUILDER_GID ]]; then
     cp -r /root/* $HOME/
     chown -R $BUILDER_UID:$BUILDER_GID $HOME/*
 
+    if [[ -e "${DOCKCROSS_ENTRYPOINT_PRE_EXEC_SCRIPT}" ]]; then
+        ${DOCKCROSS_ENTRYPOINT_PRE_EXEC_SCRIPT}
+    fi
+
     # Run the command as the specified user/group.
     exec chpst -u :$BUILDER_UID:$BUILDER_GID "$@"
 else

--- a/manylinux-x64/Dockerfile.in
+++ b/manylinux-x64/Dockerfile.in
@@ -25,4 +25,8 @@ COPY linux-x64/${CROSS_TRIPLE}-noop.sh /usr/bin/${CROSS_TRIPLE}-noop
 
 COPY manylinux-x64/Toolchain.cmake ${CROSS_ROOT}/../lib/
 ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/../lib/Toolchain.cmake
+
+COPY manylinux-x64/entrypoint-pre-exec.sh /dockcross/
+ENV DOCKCROSS_ENTRYPOINT_PRE_EXEC_SCRIPT /dockcross/entrypoint-pre-exec.sh
+
 ENV DEFAULT_DOCKCROSS_IMAGE dockcross/manylinux-x64

--- a/manylinux-x64/Dockerfile.in
+++ b/manylinux-x64/Dockerfile.in
@@ -12,6 +12,8 @@ RUN cd /opt && \
 COPY manylinux-x64/install-skbuild.sh /usr/local/bin
 RUN /usr/local/bin/install-skbuild.sh
 
+RUN yum -y install sudo
+
 ENV CROSS_TRIPLE x86_64-linux-gnu
 ENV CROSS_ROOT /opt/rh/devtoolset-2/root/usr/bin
 ENV AS=${CROSS_ROOT}/as \
@@ -25,8 +27,4 @@ COPY linux-x64/${CROSS_TRIPLE}-noop.sh /usr/bin/${CROSS_TRIPLE}-noop
 
 COPY manylinux-x64/Toolchain.cmake ${CROSS_ROOT}/../lib/
 ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/../lib/Toolchain.cmake
-
-COPY manylinux-x64/entrypoint-pre-exec.sh /dockcross/
-ENV DOCKCROSS_ENTRYPOINT_PRE_EXEC_SCRIPT /dockcross/entrypoint-pre-exec.sh
-
 ENV DEFAULT_DOCKCROSS_IMAGE dockcross/manylinux-x64

--- a/manylinux-x64/entrypoint-pre-exec.sh
+++ b/manylinux-x64/entrypoint-pre-exec.sh
@@ -1,5 +1,0 @@
-
-if [[ -n $BUILDER_UID ]] && [[ -n $BUILDER_GID ]]; then
-  chown -R $BUILDER_UID:$BUILDER_GID /opt/_internal/*
-fi
-

--- a/manylinux-x64/entrypoint-pre-exec.sh
+++ b/manylinux-x64/entrypoint-pre-exec.sh
@@ -1,0 +1,5 @@
+
+if [[ -n $BUILDER_UID ]] && [[ -n $BUILDER_GID ]]; then
+  chown -R $BUILDER_UID:$BUILDER_GID /opt/_internal/*
+fi
+


### PR DESCRIPTION

* base/entrypoint: Add support for DOCKCROSS_ENTRYPOINT_PRE_EXEC_SCRIPT

This commit teaches entrypoint.sh script to optionally execute
a "pre-exec" script allowing to (for example) change ownership
of files.

* manylinux: Add entrypoint-pre-exec.sh changing ownership of python installs

This commit allows script building wheel to pip install additional
packages.

It fixes errors like the following:

```
Exception:
Traceback (most recent call last):
  File "/opt/_internal/cpython-2.7.11-ucs2/lib/python2.7/site-packages/pip/basecommand.py", line 215, in main
    status = self.run(options, args)
  File "/opt/_internal/cpython-2.7.11-ucs2/lib/python2.7/site-packages/pip/commands/install.py", line 317, in run
    prefix=options.prefix_path,
  File "/opt/_internal/cpython-2.7.11-ucs2/lib/python2.7/site-packages/pip/req/req_set.py", line 736, in install
    requirement.uninstall(auto_confirm=True)
  File "/opt/_internal/cpython-2.7.11-ucs2/lib/python2.7/site-packages/pip/req/req_install.py", line 742, in uninstall
    paths_to_remove.remove(auto_confirm)
  File "/opt/_internal/cpython-2.7.11-ucs2/lib/python2.7/site-packages/pip/req/req_uninstall.py", line 115, in remove
    renames(path, new_path)
  File "/opt/_internal/cpython-2.7.11-ucs2/lib/python2.7/site-packages/pip/utils/__init__.py", line 267, in renames
    shutil.move(old, new)
  File "/opt/_internal/cpython-2.7.11-ucs2/lib/python2.7/shutil.py", line 303, in move
    os.unlink(src)
OSError: [Errno 13] Permission denied: '/opt/_internal/cpython-2.7.11-ucs2/bin/easy_install'
```