### PR TITLE
manylinux: Grant current user password less sudo access.

### DIFF
--- a/imagefiles/entrypoint.sh
+++ b/imagefiles/entrypoint.sh
@@ -25,6 +25,7 @@ if [[ -n $BUILDER_UID ]] && [[ -n $BUILDER_GID ]]; then
 
     groupadd -o -g $BUILDER_GID $BUILDER_GROUP 2> /dev/null
     useradd -o -m -g $BUILDER_GID -u $BUILDER_UID $BUILDER_USER 2> /dev/null
+    echo "$BUILDER_USER    ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
     export HOME=/home/${BUILDER_USER}
     shopt -s dotglob
     cp -r /root/* $HOME/

--- a/manylinux-x64/Dockerfile.in
+++ b/manylinux-x64/Dockerfile.in
@@ -12,6 +12,8 @@ RUN cd /opt && \
 COPY manylinux-x64/install-skbuild.sh /usr/local/bin
 RUN /usr/local/bin/install-skbuild.sh
 
+RUN yum -y install sudo
+
 ENV CROSS_TRIPLE x86_64-linux-gnu
 ENV CROSS_ROOT /opt/rh/devtoolset-2/root/usr/bin
 ENV AS=${CROSS_ROOT}/as \


### PR DESCRIPTION
This will allow build script like "build-wheels.sh" to run command like
the following (see [1]):

```
sudo yum install -y atlas-devel
```

It will also allow to pip install using sudo and avoid error reported in [3].

That said, instead of running pip using sudo, the recommended approach
is to specify the "--user" flag [2]

[1] https://github.com/pypa/python-manylinux-demo/blob/893d92517e9e289b9d2ee063f19c3216a39534ab/travis/build-wheels.sh

[2] http://stackoverflow.com/questions/7143077/how-can-i-install-packages-in-my-home-folder-with-pip#7143496

[3] Error reported when running pip without "sudo pip install <packagename" or "pip install --user <packagename>"
```
Exception:
Traceback (most recent call last):
  File "/opt/_internal/cpython-2.7.11-ucs2/lib/python2.7/site-packages/pip/basecommand.py", line 215, in main
    status = self.run(options, args)
  File "/opt/_internal/cpython-2.7.11-ucs2/lib/python2.7/site-packages/pip/commands/install.py", line 317, in run
    prefix=options.prefix_path,
  File "/opt/_internal/cpython-2.7.11-ucs2/lib/python2.7/site-packages/pip/req/req_set.py", line 736, in install
    requirement.uninstall(auto_confirm=True)
  File "/opt/_internal/cpython-2.7.11-ucs2/lib/python2.7/site-packages/pip/req/req_install.py", line 742, in uninstall
    paths_to_remove.remove(auto_confirm)
  File "/opt/_internal/cpython-2.7.11-ucs2/lib/python2.7/site-packages/pip/req/req_uninstall.py", line 115, in remove
    renames(path, new_path)
  File "/opt/_internal/cpython-2.7.11-ucs2/lib/python2.7/site-packages/pip/utils/__init__.py", line 267, in renames
    shutil.move(old, new)
  File "/opt/_internal/cpython-2.7.11-ucs2/lib/python2.7/shutil.py", line 303, in move
    os.unlink(src)
OSError: [Errno 13] Permission denied: '/opt/_internal/cpython-2.7.11-ucs2/bin/easy_install'
```