### PR TITLE
Tweak makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,7 @@ STANDARD_IMAGES = android-arm linux-x86 linux-x64 linux-arm64 linux-armv5 linux-
 NON_STANDARD_IMAGES = browser-asmjs manylinux-x64 manylinux-x86
 
 # This list all available images
-ALL_IMAGES = $(STANDARD_IMAGES) $(NON_STANDARD_IMAGES)
-
-# Set DEFAULT_IMAGES by excluding experimental images from ALL_IMAGES
-DEFAULT_IMAGES = $(filter-out browser-asmjs linux-ppc64le, $(ALL_IMAGES))
+IMAGES = $(STANDARD_IMAGES) $(NON_STANDARD_IMAGES)
 
 # Optional arguments for test runner (test/run.py) associated with "testing implicit rule"
 linux-ppc64le.test_ARGS = --languages C
@@ -30,14 +27,14 @@ windows-x86.test_ARGS = --exe-suffix ".exe"
 windows-x64.test_ARGS = --exe-suffix ".exe"
 
 #
-# images: This target builds all DEFAULT_IMAGES (because it is the first one, it is built by default)
+# images: This target builds all IMAGES (because it is the first one, it is built by default)
 #
-images: base $(DEFAULT_IMAGES)
+images: base $(IMAGES)
 
 #
 # test: This target ensures all IMAGES are built and run the associated tests
 #
-test: base.test $(addsuffix .test,$(DEFAULT_IMAGES))
+test: base.test $(addsuffix .test,$(IMAGES))
 
 #
 # browser-asmjs
@@ -93,13 +90,10 @@ base.test: base
 #
 # display
 #
-display_default_images:
-	for image in $(DEFAULT_IMAGES); do echo $$image; done
+display_images:
+	for image in $(IMAGES); do echo $$image; done
 
-display_all_images:
-	for image in $(ALL_IMAGES); do echo $$image; done
-
-$(VERBOSE).SILENT: display_default_images display_all_images
+$(VERBOSE).SILENT: display_images
 
 #
 # build implicit rule
@@ -115,4 +109,4 @@ $(addsuffix .test,$(STANDARD_IMAGES)): $$(basename $$@)
 	$(DOCKER) run --rm dockcross/$(basename $@) > $(BIN)/dockcross-$(basename $@) && chmod +x $(BIN)/dockcross-$(basename $@)
 	$(BIN)/dockcross-$(basename $@) python test/run.py $($@_ARGS)
 
-.PHONY: base images $(ALL_IMAGES) test %.test
+.PHONY: base images $(IMAGES) test %.test

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,6 @@ base: Dockerfile
 	$(DOCKER) build -t $(ORG)/base .
 
 base.test: base
-	mkdir -p $(BIN)
 	$(DOCKER) run --rm dockcross/base > $(BIN)/dockcross-base && chmod +x $(BIN)/dockcross-base
 
 #
@@ -108,5 +107,13 @@ $(STANDARD_IMAGES): base
 $(addsuffix .test,$(STANDARD_IMAGES)): $$(basename $$@)
 	$(DOCKER) run --rm dockcross/$(basename $@) > $(BIN)/dockcross-$(basename $@) && chmod +x $(BIN)/dockcross-$(basename $@)
 	$(BIN)/dockcross-$(basename $@) python test/run.py $($@_ARGS)
+
+#
+# testing prerequisites implicit rule
+#
+test.prerequisites:
+	mkdir -p $(BIN)
+
+$(addsuffix .test,$(IMAGES)): test.prerequisites
 
 .PHONY: base images $(IMAGES) test %.test

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,9 @@ STANDARD_IMAGES = android-arm linux-x86 linux-x64 linux-arm64 linux-armv5 linux-
 
 IMAGES = $(STANDARD_IMAGES) manylinux-x64 manylinux-x86
 
-STANDARD_TESTS = android-arm linux-x86 linux-x64 linux-arm64 linux-armv5 linux-armv6 linux-armv7
+# Arguments for test/run.py associated with standard images
+windows-x86.test_ARGS = --exe-suffix ".exe"
+windows-x64.test_ARGS = --exe-suffix ".exe"
 
 images: base $(IMAGES)
 
@@ -16,9 +18,9 @@ $(STANDARD_IMAGES): base
 	$(DOCKER) build -t $(ORG)/$@ $@
 
 .SECONDEXPANSION:
-$(addsuffix .test,$(STANDARD_TESTS)): $$(basename $$@)
+$(addsuffix .test,$(STANDARD_IMAGES)): $$(basename $$@)
 	$(DOCKER) run --rm dockcross/$(basename $@) > $(BIN)/dockcross-$(basename $@) && chmod +x $(BIN)/dockcross-$(basename $@)
-	$(BIN)/dockcross-$(basename $@) python test/run.py
+	$(BIN)/dockcross-$(basename $@) python test/run.py $($@_ARGS)
 
 browser-asmjs: base
 	cp -r test browser-asmjs/
@@ -55,14 +57,6 @@ manylinux-x86: manylinux-x86/Dockerfile
 manylinux-x86.test: manylinux-x86
 	$(DOCKER) run --rm dockcross/manylinux-x86 > $(BIN)/dockcross-manylinux-x86 && chmod +x $(BIN)/dockcross-manylinux-x86
 	$(BIN)/dockcross-manylinux-x86 /opt/python/cp35-cp35m/bin/python test/run.py
-
-windows-x86.test: windows-x86
-	$(DOCKER) run --rm dockcross/windows-x86 > $(BIN)/dockcross-windows-x86 && chmod +x $(BIN)/dockcross-windows-x86
-	$(BIN)/dockcross-windows-x86 python test/run.py  --exe-suffix ".exe"
-
-windows-x64.test: windows-x64
-	$(DOCKER) run --rm dockcross/windows-x64 > $(BIN)/dockcross-windows-x64 && chmod +x $(BIN)/dockcross-windows-x64
-	$(BIN)/dockcross-windows-x64 python test/run.py --exe-suffix ".exe"
 
 Dockerfile: Dockerfile.in common.docker
 	sed '/common.docker/ r common.docker' Dockerfile.in > Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ IMAGES = android-arm linux-x86 linux-x64 manylinux-x64 manylinux-x86 linux-arm64
 
 images: base $(IMAGES)
 
-test: base.test android-arm.test linux-x86.test linux-x64.test manylinux-x64.test manylinux-x86.test linux-arm64.test linux-armv5.test linux-armv6.test linux-armv7.test windows-x86.test windows-x64.test
+test: base.test $(addsuffix .test,$(IMAGES))
 
 android-arm: base android-arm/Dockerfile
 	$(DOCKER) build -t $(ORG)/android-arm android-arm

--- a/Makefile
+++ b/Makefile
@@ -7,68 +7,68 @@ images: base $(IMAGES)
 
 test: base.test $(addsuffix .test,$(IMAGES))
 
-android-arm: base android-arm/Dockerfile
+android-arm: base
 	$(DOCKER) build -t $(ORG)/android-arm android-arm
 
-android-arm.test: android-arm test/run.py
+android-arm.test: android-arm
 	$(DOCKER) run --rm dockcross/android-arm > $(BIN)/dockcross-android-arm && chmod +x $(BIN)/dockcross-android-arm
 	$(BIN)/dockcross-android-arm python test/run.py
 
-browser-asmjs: base browser-asmjs/Dockerfile
+browser-asmjs: base
 	cp -r test browser-asmjs/
 	$(DOCKER) build -t $(ORG)/browser-asmjs browser-asmjs
 	rm -rf browser-asmjs/test
 
-browser-asmjs.test: browser-asmjs test/run.py
+browser-asmjs.test: browser-asmjs
 	$(DOCKER) run --rm dockcross/browser-asmjs > $(BIN)/dockcross-browser-asmjs && chmod +x $(BIN)/dockcross-browser-asmjs
 	$(BIN)/dockcross-browser-asmjs python test/run.py --exe-suffix ".js"
 
-linux-x86: base linux-x86/Dockerfile
+linux-x86: base
 	$(DOCKER) build -t $(ORG)/linux-x86 linux-x86
 
-linux-x86.test: linux-x86 test/run.py
+linux-x86.test: linux-x86
 	$(DOCKER) run --rm dockcross/linux-x86 > $(BIN)/dockcross-linux-x86 && chmod +x $(BIN)/dockcross-linux-x86
 	$(BIN)/dockcross-linux-x86 python test/run.py
 
-linux-x64: base linux-x64/Dockerfile
+linux-x64: base
 	$(DOCKER) build -t $(ORG)/linux-x64 linux-x64
 
-linux-x64.test: linux-x64 test/run.py
+linux-x64.test: linux-x64
 	$(DOCKER) run --rm dockcross/linux-x64 > $(BIN)/dockcross-linux-x64 && chmod +x $(BIN)/dockcross-linux-x64
 	$(BIN)/dockcross-linux-x64 python test/run.py
 
-linux-arm64: base linux-arm64/Dockerfile
+linux-arm64: base
 	$(DOCKER) build -t $(ORG)/linux-arm64 linux-arm64
 
-linux-arm64.test: linux-arm64 test/run.py
+linux-arm64.test: linux-arm64
 	$(DOCKER) run --rm dockcross/linux-arm64 > $(BIN)/dockcross-linux-arm64 && chmod +x $(BIN)/dockcross-linux-arm64
 	$(BIN)/dockcross-linux-arm64 python test/run.py
 
-linux-armv5: base linux-armv5/Dockerfile
+linux-armv5: base
 	$(DOCKER) build -t $(ORG)/linux-armv5 linux-armv5
 
-linux-armv5.test: linux-armv5 test/run.py
+linux-armv5.test: linux-armv5
 	$(DOCKER) run --rm dockcross/linux-armv5 > $(BIN)/dockcross-linux-armv5 && chmod +x $(BIN)/dockcross-linux-armv5
 	$(BIN)/dockcross-linux-armv5 python test/run.py
 
-linux-armv6: base linux-armv6/Dockerfile
+linux-armv6: base
 	$(DOCKER) build -t $(ORG)/linux-armv6 linux-armv6
 
-linux-armv6.test: linux-armv6 test/run.py
+linux-armv6.test: linux-armv6
 	$(DOCKER) run --rm dockcross/linux-armv6 > $(BIN)/dockcross-linux-armv6 && chmod +x $(BIN)/dockcross-linux-armv6
 	$(BIN)/dockcross-linux-armv6 python test/run.py
 
-linux-armv7: base linux-armv7/Dockerfile
+linux-armv7: base
 	$(DOCKER) build -t $(ORG)/linux-armv7 linux-armv7
 
-linux-armv7.test: linux-armv7 test/run.py
+linux-armv7.test: linux-armv7
 	$(DOCKER) run --rm dockcross/linux-armv7 > $(BIN)/dockcross-linux-armv7 && chmod +x $(BIN)/dockcross-linux-armv7
 	$(BIN)/dockcross-linux-armv7 python test/run.py
 
-linux-ppc64le: base linux-ppc64le/Dockerfile
+linux-ppc64le: base
 	$(DOCKER) build -t $(ORG)/linux-ppc64le linux-ppc64le
 
-linux-ppc64le.test: linux-ppc64le test/run.py
+linux-ppc64le.test: linux-ppc64le
 	$(DOCKER) run --rm dockcross/linux-ppc64le > $(BIN)/dockcross-linux-ppc64le && chmod +x $(BIN)/dockcross-linux-ppc64le
 	$(BIN)/dockcross-linux-ppc64le python test/run.py --languages C
 
@@ -78,7 +78,7 @@ manylinux-x64/Dockerfile: manylinux-x64/Dockerfile.in common.docker
 manylinux-x64: manylinux-x64/Dockerfile
 	$(DOCKER) build -t $(ORG)/manylinux-x64 -f manylinux-x64/Dockerfile .
 
-manylinux-x64.test: manylinux-x64 test/run.py
+manylinux-x64.test: manylinux-x64
 	$(DOCKER) run --rm dockcross/manylinux-x64 > $(BIN)/dockcross-manylinux-x64 && chmod +x $(BIN)/dockcross-manylinux-x64
 	$(BIN)/dockcross-manylinux-x64 /opt/python/cp35-cp35m/bin/python test/run.py
 
@@ -88,21 +88,21 @@ manylinux-x86/Dockerfile: manylinux-x86/Dockerfile.in common.docker
 manylinux-x86: manylinux-x86/Dockerfile
 	$(DOCKER) build -t $(ORG)/manylinux-x86 -f manylinux-x86/Dockerfile .
 
-manylinux-x86.test: manylinux-x86 test/run.py
+manylinux-x86.test: manylinux-x86
 	$(DOCKER) run --rm dockcross/manylinux-x86 > $(BIN)/dockcross-manylinux-x86 && chmod +x $(BIN)/dockcross-manylinux-x86
 	$(BIN)/dockcross-manylinux-x86 /opt/python/cp35-cp35m/bin/python test/run.py
 
-windows-x86: base windows-x86/Dockerfile windows-x86/settings.mk
+windows-x86: base
 	$(DOCKER) build -t $(ORG)/windows-x86 windows-x86
 
-windows-x86.test: windows-x86 test/run.py
+windows-x86.test: windows-x86
 	$(DOCKER) run --rm dockcross/windows-x86 > $(BIN)/dockcross-windows-x86 && chmod +x $(BIN)/dockcross-windows-x86
 	$(BIN)/dockcross-windows-x86 python test/run.py  --exe-suffix ".exe"
 
-windows-x64: base windows-x64/Dockerfile windows-x64/settings.mk
+windows-x64: base
 	$(DOCKER) build -t $(ORG)/windows-x64 windows-x64
 
-windows-x64.test: windows-x64 test/run.py
+windows-x64.test: windows-x64
 	$(DOCKER) run --rm dockcross/windows-x64 > $(BIN)/dockcross-windows-x64 && chmod +x $(BIN)/dockcross-windows-x64
 	$(BIN)/dockcross-windows-x64 python test/run.py --exe-suffix ".exe"
 
@@ -112,7 +112,7 @@ Dockerfile: Dockerfile.in common.docker
 base: Dockerfile
 	$(DOCKER) build -t $(ORG)/base .
 
-base.test: base test/run.py
+base.test: base
 	mkdir -p $(BIN)
 	$(DOCKER) run --rm dockcross/base > $(BIN)/dockcross-base && chmod +x $(BIN)/dockcross-base
 

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,17 @@
 DOCKER = docker
 ORG = dockcross
 BIN = bin
-IMAGES = android-arm linux-x86 linux-x64 manylinux-x64 manylinux-x86 linux-arm64 linux-armv5 linux-armv6 linux-armv7 windows-x86 windows-x64
+
+STANDARD_IMAGES = android-arm linux-x86 linux-x64 linux-arm64 linux-armv5 linux-armv6 linux-armv7 windows-x86 windows-x64
+
+IMAGES = $(STANDARD_IMAGES) manylinux-x64 manylinux-x86
 
 images: base $(IMAGES)
 
 test: base.test $(addsuffix .test,$(IMAGES))
 
-android-arm: base
-	$(DOCKER) build -t $(ORG)/android-arm android-arm
+$(STANDARD_IMAGES): base
+	$(DOCKER) build -t $(ORG)/$@ $@
 
 android-arm.test: android-arm
 	$(DOCKER) run --rm dockcross/android-arm > $(BIN)/dockcross-android-arm && chmod +x $(BIN)/dockcross-android-arm
@@ -23,43 +26,25 @@ browser-asmjs.test: browser-asmjs
 	$(DOCKER) run --rm dockcross/browser-asmjs > $(BIN)/dockcross-browser-asmjs && chmod +x $(BIN)/dockcross-browser-asmjs
 	$(BIN)/dockcross-browser-asmjs python test/run.py --exe-suffix ".js"
 
-linux-x86: base
-	$(DOCKER) build -t $(ORG)/linux-x86 linux-x86
-
 linux-x86.test: linux-x86
 	$(DOCKER) run --rm dockcross/linux-x86 > $(BIN)/dockcross-linux-x86 && chmod +x $(BIN)/dockcross-linux-x86
 	$(BIN)/dockcross-linux-x86 python test/run.py
-
-linux-x64: base
-	$(DOCKER) build -t $(ORG)/linux-x64 linux-x64
 
 linux-x64.test: linux-x64
 	$(DOCKER) run --rm dockcross/linux-x64 > $(BIN)/dockcross-linux-x64 && chmod +x $(BIN)/dockcross-linux-x64
 	$(BIN)/dockcross-linux-x64 python test/run.py
 
-linux-arm64: base
-	$(DOCKER) build -t $(ORG)/linux-arm64 linux-arm64
-
 linux-arm64.test: linux-arm64
 	$(DOCKER) run --rm dockcross/linux-arm64 > $(BIN)/dockcross-linux-arm64 && chmod +x $(BIN)/dockcross-linux-arm64
 	$(BIN)/dockcross-linux-arm64 python test/run.py
-
-linux-armv5: base
-	$(DOCKER) build -t $(ORG)/linux-armv5 linux-armv5
 
 linux-armv5.test: linux-armv5
 	$(DOCKER) run --rm dockcross/linux-armv5 > $(BIN)/dockcross-linux-armv5 && chmod +x $(BIN)/dockcross-linux-armv5
 	$(BIN)/dockcross-linux-armv5 python test/run.py
 
-linux-armv6: base
-	$(DOCKER) build -t $(ORG)/linux-armv6 linux-armv6
-
 linux-armv6.test: linux-armv6
 	$(DOCKER) run --rm dockcross/linux-armv6 > $(BIN)/dockcross-linux-armv6 && chmod +x $(BIN)/dockcross-linux-armv6
 	$(BIN)/dockcross-linux-armv6 python test/run.py
-
-linux-armv7: base
-	$(DOCKER) build -t $(ORG)/linux-armv7 linux-armv7
 
 linux-armv7.test: linux-armv7
 	$(DOCKER) run --rm dockcross/linux-armv7 > $(BIN)/dockcross-linux-armv7 && chmod +x $(BIN)/dockcross-linux-armv7
@@ -92,15 +77,9 @@ manylinux-x86.test: manylinux-x86
 	$(DOCKER) run --rm dockcross/manylinux-x86 > $(BIN)/dockcross-manylinux-x86 && chmod +x $(BIN)/dockcross-manylinux-x86
 	$(BIN)/dockcross-manylinux-x86 /opt/python/cp35-cp35m/bin/python test/run.py
 
-windows-x86: base
-	$(DOCKER) build -t $(ORG)/windows-x86 windows-x86
-
 windows-x86.test: windows-x86
 	$(DOCKER) run --rm dockcross/windows-x86 > $(BIN)/dockcross-windows-x86 && chmod +x $(BIN)/dockcross-windows-x86
 	$(BIN)/dockcross-windows-x86 python test/run.py  --exe-suffix ".exe"
-
-windows-x64: base
-	$(DOCKER) build -t $(ORG)/windows-x64 windows-x64
 
 windows-x64.test: windows-x64
 	$(DOCKER) run --rm dockcross/windows-x64 > $(BIN)/dockcross-windows-x64 && chmod +x $(BIN)/dockcross-windows-x64

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ STANDARD_IMAGES = android-arm linux-x86 linux-x64 linux-arm64 linux-armv5 linux-
 
 IMAGES = $(STANDARD_IMAGES) manylinux-x64 manylinux-x86
 
+STANDARD_TESTS = android-arm linux-x86 linux-x64 linux-arm64 linux-armv5 linux-armv6 linux-armv7
+
 images: base $(IMAGES)
 
 test: base.test $(addsuffix .test,$(IMAGES))
@@ -13,9 +15,10 @@ test: base.test $(addsuffix .test,$(IMAGES))
 $(STANDARD_IMAGES): base
 	$(DOCKER) build -t $(ORG)/$@ $@
 
-android-arm.test: android-arm
-	$(DOCKER) run --rm dockcross/android-arm > $(BIN)/dockcross-android-arm && chmod +x $(BIN)/dockcross-android-arm
-	$(BIN)/dockcross-android-arm python test/run.py
+.SECONDEXPANSION:
+$(addsuffix .test,$(STANDARD_TESTS)): $$(basename $$@)
+	$(DOCKER) run --rm dockcross/$(basename $@) > $(BIN)/dockcross-$(basename $@) && chmod +x $(BIN)/dockcross-$(basename $@)
+	$(BIN)/dockcross-$(basename $@) python test/run.py
 
 browser-asmjs: base
 	cp -r test browser-asmjs/
@@ -25,30 +28,6 @@ browser-asmjs: base
 browser-asmjs.test: browser-asmjs
 	$(DOCKER) run --rm dockcross/browser-asmjs > $(BIN)/dockcross-browser-asmjs && chmod +x $(BIN)/dockcross-browser-asmjs
 	$(BIN)/dockcross-browser-asmjs python test/run.py --exe-suffix ".js"
-
-linux-x86.test: linux-x86
-	$(DOCKER) run --rm dockcross/linux-x86 > $(BIN)/dockcross-linux-x86 && chmod +x $(BIN)/dockcross-linux-x86
-	$(BIN)/dockcross-linux-x86 python test/run.py
-
-linux-x64.test: linux-x64
-	$(DOCKER) run --rm dockcross/linux-x64 > $(BIN)/dockcross-linux-x64 && chmod +x $(BIN)/dockcross-linux-x64
-	$(BIN)/dockcross-linux-x64 python test/run.py
-
-linux-arm64.test: linux-arm64
-	$(DOCKER) run --rm dockcross/linux-arm64 > $(BIN)/dockcross-linux-arm64 && chmod +x $(BIN)/dockcross-linux-arm64
-	$(BIN)/dockcross-linux-arm64 python test/run.py
-
-linux-armv5.test: linux-armv5
-	$(DOCKER) run --rm dockcross/linux-armv5 > $(BIN)/dockcross-linux-armv5 && chmod +x $(BIN)/dockcross-linux-armv5
-	$(BIN)/dockcross-linux-armv5 python test/run.py
-
-linux-armv6.test: linux-armv6
-	$(DOCKER) run --rm dockcross/linux-armv6 > $(BIN)/dockcross-linux-armv6 && chmod +x $(BIN)/dockcross-linux-armv6
-	$(BIN)/dockcross-linux-armv6 python test/run.py
-
-linux-armv7.test: linux-armv7
-	$(DOCKER) run --rm dockcross/linux-armv7 > $(BIN)/dockcross-linux-armv7 && chmod +x $(BIN)/dockcross-linux-armv7
-	$(BIN)/dockcross-linux-armv7 python test/run.py
 
 linux-ppc64le: base
 	$(DOCKER) build -t $(ORG)/linux-ppc64le linux-ppc64le

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ browser-asmjs.test: browser-asmjs test/run.py
 	$(DOCKER) run --rm dockcross/browser-asmjs > $(BIN)/dockcross-browser-asmjs && chmod +x $(BIN)/dockcross-browser-asmjs
 	$(BIN)/dockcross-browser-asmjs python test/run.py --exe-suffix ".js"
 
-linux-x86: base linux-x86/Dockerfile linux-x86/Toolchain.cmake
+linux-x86: base linux-x86/Dockerfile
 	$(DOCKER) build -t $(ORG)/linux-x86 linux-x86
 
 linux-x86.test: linux-x86 test/run.py
@@ -37,35 +37,35 @@ linux-x64.test: linux-x64 test/run.py
 	$(DOCKER) run --rm dockcross/linux-x64 > $(BIN)/dockcross-linux-x64 && chmod +x $(BIN)/dockcross-linux-x64
 	$(BIN)/dockcross-linux-x64 python test/run.py
 
-linux-arm64: base linux-arm64/Dockerfile linux-arm64/Toolchain.cmake
+linux-arm64: base linux-arm64/Dockerfile
 	$(DOCKER) build -t $(ORG)/linux-arm64 linux-arm64
 
 linux-arm64.test: linux-arm64 test/run.py
 	$(DOCKER) run --rm dockcross/linux-arm64 > $(BIN)/dockcross-linux-arm64 && chmod +x $(BIN)/dockcross-linux-arm64
 	$(BIN)/dockcross-linux-arm64 python test/run.py
 
-linux-armv5: base linux-armv5/Dockerfile linux-armv5/Toolchain.cmake
+linux-armv5: base linux-armv5/Dockerfile
 	$(DOCKER) build -t $(ORG)/linux-armv5 linux-armv5
 
 linux-armv5.test: linux-armv5 test/run.py
 	$(DOCKER) run --rm dockcross/linux-armv5 > $(BIN)/dockcross-linux-armv5 && chmod +x $(BIN)/dockcross-linux-armv5
 	$(BIN)/dockcross-linux-armv5 python test/run.py
 
-linux-armv6: base linux-armv6/Dockerfile linux-armv6/Toolchain.cmake
+linux-armv6: base linux-armv6/Dockerfile
 	$(DOCKER) build -t $(ORG)/linux-armv6 linux-armv6
 
 linux-armv6.test: linux-armv6 test/run.py
 	$(DOCKER) run --rm dockcross/linux-armv6 > $(BIN)/dockcross-linux-armv6 && chmod +x $(BIN)/dockcross-linux-armv6
 	$(BIN)/dockcross-linux-armv6 python test/run.py
 
-linux-armv7: base linux-armv7/Dockerfile linux-armv7/Toolchain.cmake
+linux-armv7: base linux-armv7/Dockerfile
 	$(DOCKER) build -t $(ORG)/linux-armv7 linux-armv7
 
 linux-armv7.test: linux-armv7 test/run.py
 	$(DOCKER) run --rm dockcross/linux-armv7 > $(BIN)/dockcross-linux-armv7 && chmod +x $(BIN)/dockcross-linux-armv7
 	$(BIN)/dockcross-linux-armv7 python test/run.py
 
-linux-ppc64le: base linux-ppc64le/Dockerfile linux-ppc64le/Toolchain.cmake
+linux-ppc64le: base linux-ppc64le/Dockerfile
 	$(DOCKER) build -t $(ORG)/linux-ppc64le linux-ppc64le
 
 linux-ppc64le.test: linux-ppc64le test/run.py

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 DOCKER = docker
 ORG = dockcross
 BIN = bin
+IMAGES = android-arm linux-x86 linux-x64 manylinux-x64 manylinux-x86 linux-arm64 linux-armv5 linux-armv6 linux-armv7 windows-x86 windows-x64
 
-images: base android-arm linux-x86 linux-x64 manylinux-x64 manylinux-x86 linux-arm64 linux-armv5 linux-armv6 linux-armv7 windows-x86 windows-x64
+images: base $(IMAGES)
 
 test: base.test android-arm.test linux-x86.test linux-x64.test manylinux-x64.test manylinux-x86.test linux-arm64.test linux-armv5.test linux-armv6.test linux-armv7.test windows-x86.test windows-x64.test
 
@@ -115,4 +116,4 @@ base.test: base test/run.py
 	mkdir -p $(BIN)
 	$(DOCKER) run --rm dockcross/base > $(BIN)/dockcross-base && chmod +x $(BIN)/dockcross-base
 
-.PHONY: images base android-arm linux-x86 linux-x64 manylinux-x64 manylinux-x86 linux-arm64 linux-armv5 linux-armv6 linux-armv7 windows-x86 windows-x64 tests %.test
+.PHONY: base images $(IMAGES) tests %.test

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,17 @@ base.test: base
 	$(DOCKER) run --rm dockcross/base > $(BIN)/dockcross-base && chmod +x $(BIN)/dockcross-base
 
 #
+# display
+#
+display_default_images:
+	for image in $(DEFAULT_IMAGES); do echo $$image; done
+
+display_all_images:
+	for image in $(ALL_IMAGES); do echo $$image; done
+
+$(VERBOSE).SILENT: display_default_images display_all_images
+
+#
 # build implicit rule
 #
 $(STANDARD_IMAGES): base

--- a/README.rst
+++ b/README.rst
@@ -183,11 +183,10 @@ source cross-compiler Docker image or the dockcross script itself.
 Download all images
 -------------------
 
-To easily download all images, the convenience target ``display_all_images`` or ``display_default_images``
-could be used::
+To easily download all images, the convenience target ``display_images`` could be used::
 
   curl https://raw.githubusercontent.com/dockcross/dockcross/master/Makefile -o dockcross-Makefile
-  for image in $(make -f dockcross-Makefile display_all_images); do
+  for image in $(make -f dockcross-Makefile display_images); do
     echo "Pulling dockcross/$image"
     docker pull dockcross/$image
   done
@@ -196,10 +195,10 @@ Install all dockcross scripts
 -----------------------------
 
 To automatically install in ``~/bin`` the dockcross scripts for each images already downloaded, the
-convenience target ``display_all_images`` or ``display_default_images`` could be used::
+convenience target ``display_images`` could be used::
 
   curl https://raw.githubusercontent.com/dockcross/dockcross/master/Makefile -o dockcross-Makefile
-  for image in $(make -f dockcross-Makefile display_all_images); do
+  for image in $(make -f dockcross-Makefile display_images); do
     if [[ $(docker images -q dockcross/$image) == "" ]]; then
       echo "~/bin/dockcross-$image skipping: image not found locally"
       continue

--- a/README.rst
+++ b/README.rst
@@ -180,6 +180,36 @@ source cross-compiler Docker image or the dockcross script itself.
 - ``dockcross update``: Update both the docker image, and the dockcross script.
 
 
+Download all images
+-------------------
+
+To easily download all images, the convenience target ``display_all_images`` or ``display_default_images``
+could be used::
+
+  curl https://raw.githubusercontent.com/dockcross/dockcross/master/Makefile -o dockcross-Makefile
+  for image in $(make -f dockcross-Makefile display_all_images); do
+    echo "Pulling dockcross/$image"
+    docker pull dockcross/$image
+  done
+
+Install all dockcross scripts
+-----------------------------
+
+To automatically install in ``~/bin`` the dockcross scripts for each images already downloaded, the
+convenience target ``display_all_images`` or ``display_default_images`` could be used::
+
+  curl https://raw.githubusercontent.com/dockcross/dockcross/master/Makefile -o dockcross-Makefile
+  for image in $(make -f dockcross-Makefile display_all_images); do
+    if [[ $(docker images -q dockcross/$image) == "" ]]; then
+      echo "~/bin/dockcross-$image skipping: image not found locally"
+      continue
+    fi
+    echo "~/bin/dockcross-$image ok"
+    docker run dockcross/$image > ~/bin/dockcross-$image && \
+    chmod u+x  ~/bin/dockcross-$image
+  done
+
+
 Configuration
 -------------
 

--- a/circle.yml
+++ b/circle.yml
@@ -14,32 +14,13 @@ dependencies:
     - docker info
     - if [[ -e ~/docker/base.tar ]]; then docker load -i ~/docker/base.tar; fi
     - docker pull dockcross/base
-    - if [[ -e ~/docker/android-arm.tar ]]; then docker load -i ~/docker/android-arm.tar; fi
-    - docker pull dockcross/android-arm
-    - if [[ -e ~/docker/browser-asmjs.tar ]]; then docker load -i ~/docker/browser-asmjs.tar; fi
-    - docker pull dockcross/browser-asmjs
-    - if [[ -e ~/docker/linux-arm64.tar ]]; then docker load -i ~/docker/linux-arm64.tar; fi
-    - docker pull dockcross/linux-arm64
-    - if [[ -e ~/docker/linux-armv5.tar ]]; then docker load -i ~/docker/linux-armv5.tar; fi
-    - docker pull dockcross/linux-armv5
-    - if [[ -e ~/docker/linux-armv6.tar ]]; then docker load -i ~/docker/linux-armv6.tar; fi
-    - docker pull dockcross/linux-armv6
-    - if [[ -e ~/docker/linux-armv7.tar ]]; then docker load -i ~/docker/linux-armv7.tar; fi
-    - docker pull dockcross/linux-armv7
-    - if [[ -e ~/docker/linux-ppc64le.tar ]]; then docker load -i ~/docker/linux-ppc64le.tar; fi
-    - docker pull dockcross/linux-ppc64le
-    - if [[ -e ~/docker/linux-x64.tar ]]; then docker load -i ~/docker/linux-x64.tar; fi
-    - docker pull dockcross/linux-x64
-    - if [[ -e ~/docker/linux-x86.tar ]]; then docker load -i ~/docker/linux-x86.tar; fi
-    - docker pull dockcross/linux-x86
-    - if [[ -e ~/docker/manylinux-x64.tar ]]; then docker load -i ~/docker/manylinux-x64.tar; fi
-    - docker pull dockcross/manylinux-x64
-    - if [[ -e ~/docker/manylinux-x86.tar ]]; then docker load -i ~/docker/manylinux-x86.tar; fi
-    - docker pull dockcross/manylinux-x86
-    - if [[ -e ~/docker/windows-x64.tar ]]; then docker load -i ~/docker/windows-x64.tar; fi
-    - docker pull dockcross/windows-x64
-    - if [[ -e ~/docker/windows-x86.tar ]]; then docker load -i ~/docker/windows-x86.tar; fi
-    - docker pull dockcross/windows-x86
+    - |
+      for image in $(make display_images); do
+        if [[ -e ~/docker/$image.tar ]]; then
+          echo "Loading $image.tar"
+          docker load -i ~/docker/$image.tar;
+        fi
+        docker pull dockcross/$image
 
 test:
   override:
@@ -80,16 +61,4 @@ deployment:
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push dockcross/base
-      - docker push dockcross/android-arm
-      - docker push dockcross/browser-asmjs
-      - docker push dockcross/linux-arm64
-      - docker push dockcross/linux-armv5
-      - docker push dockcross/linux-armv6
-      - docker push dockcross/linux-armv7
-      - docker push dockcross/linux-ppc64le
-      - docker push dockcross/linux-x64
-      - docker push dockcross/linux-x86
-      - docker push dockcross/manylinux-x64
-      - docker push dockcross/manylinux-x86
-      - docker push dockcross/windows-x64
-      - docker push dockcross/windows-x86
+      - for image in $(make display_images); do docker push dockcross/$image; done


### PR DESCRIPTION
This topic improves and simplifies the `Makefile`:
* Add documentation
* Define image as either `standard` or `non-standard`
* Create  `ALL_IMAGES` and `DEFAULT_IMAGES` categories
* Make use of implicit build and testing rules if relevant
* Add convenience targets `display_all_images` and `display_default_images`, and also document how to easily download all images and/or install all dockcross scripts into `~/bin`.

To make sure that no regression were introduced, the output of `make --dry-run` was compared before and after each commit. See below for more details.


### Compare before and after

To confirm that the Makefiles works as expected after this patch, the
list of executed commands before and after is compared:

Before:

browser-asmjs linux-ppc64le

```
make --dry-run > ../dockcross-make-baseline
make test --dry-run > ../dockcross-make-test-baseline
make browser-asmjs.test --dry-run > ../dockcross-make-browser-asmjs-test-baseline
make linux-ppc64le.test --dry-run > ../dockcross-make-linux-ppc64le-test-baseline
```

After: 

```
make --dry-run > ../dockcross-make-current;
make test --dry-run > ../dockcross-make-test-current
make browser-asmjs.test --dry-run > ../dockcross-make-browser-asmjs-test-current
make linux-ppc64le.test --dry-run > ../dockcross-make-linux-ppc64le-test-current

for target in make make-test make-browser-asmjs-test make-linux-ppc64le-test; do
  diff --ignore-trailing-space ../dockcross-$target-current ../dockcross-$target-baseline > /dev/null 2>&1
  [[ $? == 1 ]] && \
    echo "" && \
    echo "Error: Problem with '${target}' target: Dry-run output before and after this commit do not match."
done
```
