### PR TITLE
dockerfile: Keep track of buildtime metadata

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -34,3 +34,14 @@ RUN apt-get update && apt-get -y install \
   apt-get -y clean
 
 #include "common.docker"
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,12 @@ test: base.test $(addsuffix .test,$(IMAGES))
 #
 browser-asmjs: base
 	cp -r test browser-asmjs/
-	$(DOCKER) build -t $(ORG)/browser-asmjs browser-asmjs
+	$(DOCKER) build -t $(ORG)/browser-asmjs \
+		--build-arg IMAGE=$(ORG)/browser-asmjs \
+		--build-arg VCS_REF=`git rev-parse --short HEAD` \
+		--build-arg VCS_URL=`git config --get remote.origin.url` \
+		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+		browser-asmjs
 	rm -rf browser-asmjs/test
 
 browser-asmjs.test: browser-asmjs
@@ -55,7 +60,12 @@ manylinux-x64/Dockerfile: manylinux-x64/Dockerfile.in common.docker
 	sed '/common.docker/ r common.docker' manylinux-x64/Dockerfile.in > manylinux-x64/Dockerfile
 
 manylinux-x64: manylinux-x64/Dockerfile
-	$(DOCKER) build -t $(ORG)/manylinux-x64 -f manylinux-x64/Dockerfile .
+	$(DOCKER) build -t $(ORG)/manylinux-x64 \
+		--build-arg IMAGE=$(ORG)/manylinux-x64 \
+		--build-arg VCS_REF=`git rev-parse --short HEAD` \
+		--build-arg VCS_URL=`git config --get remote.origin.url` \
+		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+		-f manylinux-x64/Dockerfile .
 
 manylinux-x64.test: manylinux-x64
 	$(DOCKER) run --rm dockcross/manylinux-x64 > $(BIN)/dockcross-manylinux-x64 && chmod +x $(BIN)/dockcross-manylinux-x64
@@ -68,7 +78,12 @@ manylinux-x86/Dockerfile: manylinux-x86/Dockerfile.in common.docker
 	sed '/common.docker/ r common.docker' manylinux-x86/Dockerfile.in > manylinux-x86/Dockerfile
 
 manylinux-x86: manylinux-x86/Dockerfile
-	$(DOCKER) build -t $(ORG)/manylinux-x86 -f manylinux-x86/Dockerfile .
+	$(DOCKER) build -t $(ORG)/manylinux-x86 \
+		--build-arg IMAGE=$(ORG)/manylinux-x86 \
+		--build-arg VCS_REF=`git rev-parse --short HEAD` \
+		--build-arg VCS_URL=`git config --get remote.origin.url` \
+		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+		-f manylinux-x86/Dockerfile .
 
 manylinux-x86.test: manylinux-x86
 	$(DOCKER) run --rm dockcross/manylinux-x86 > $(BIN)/dockcross-manylinux-x86 && chmod +x $(BIN)/dockcross-manylinux-x86
@@ -81,7 +96,12 @@ Dockerfile: Dockerfile.in common.docker
 	sed '/common.docker/ r common.docker' Dockerfile.in > Dockerfile
 
 base: Dockerfile
-	$(DOCKER) build -t $(ORG)/base .
+	$(DOCKER) build -t $(ORG)/base \
+		--build-arg IMAGE=$(ORG)/base \
+		--build-arg VCS_REF=`git rev-parse --short HEAD` \
+		--build-arg VCS_URL=`git config --get remote.origin.url` \
+		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+		.
 
 base.test: base
 	$(DOCKER) run --rm dockcross/base > $(BIN)/dockcross-base && chmod +x $(BIN)/dockcross-base
@@ -98,7 +118,12 @@ $(VERBOSE).SILENT: display_images
 # build implicit rule
 #
 $(STANDARD_IMAGES): base
-	$(DOCKER) build -t $(ORG)/$@ $@
+	$(DOCKER) build -t $(ORG)/$@ \
+		--build-arg IMAGE=$(ORG)/$@ \
+		--build-arg VCS_REF=`git rev-parse --short HEAD` \
+		--build-arg VCS_URL=`git config --get remote.origin.url` \
+		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+		$@
 
 #
 # testing implicit rule

--- a/android-arm/Dockerfile
+++ b/android-arm/Dockerfile
@@ -38,3 +38,14 @@ ENV DEFAULT_DOCKCROSS_IMAGE dockcross/android-arm
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
 ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/browser-asmjs/Dockerfile
+++ b/browser-asmjs/Dockerfile
@@ -49,3 +49,13 @@ ENV CMAKE_TOOLCHAIN_FILE /usr/emsdk_portable/emscripten/tag-${EMSCRIPTEN_VERSION
 # https://github.com/kripken/emscripten/pull/4477
 RUN sed -i -e '/CMakeForceCompiler/d' -e '/CMAKE_FORCE_C/d' $CMAKE_TOOLCHAIN_FILE
 
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/linux-arm64/Dockerfile
+++ b/linux-arm64/Dockerfile
@@ -42,3 +42,14 @@ WORKDIR /work
 # We can switch to that when it becomes stable.
 COPY Toolchain.cmake /usr/lib/${CROSS_TRIPLE}/
 ENV CMAKE_TOOLCHAIN_FILE /usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/linux-armv5/Dockerfile
+++ b/linux-armv5/Dockerfile
@@ -32,3 +32,14 @@ ENV DEFAULT_DOCKCROSS_IMAGE dockcross/linux-armv5
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
 ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/linux-armv6/Dockerfile
+++ b/linux-armv6/Dockerfile
@@ -43,3 +43,14 @@ ENV DEFAULT_DOCKCROSS_IMAGE dockcross/linux-armv6
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
 ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/linux-armv7/Dockerfile
+++ b/linux-armv7/Dockerfile
@@ -31,3 +31,14 @@ ENV DEFAULT_DOCKCROSS_IMAGE dockcross/linux-armv7
 # https://wiki.debian.org/CrossToolchains#In_jessie_.28Debian_8.29
 COPY Toolchain.cmake /usr/lib/${CROSS_TRIPLE}/
 ENV CMAKE_TOOLCHAIN_FILE /usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/linux-ppc64le/Dockerfile
+++ b/linux-ppc64le/Dockerfile
@@ -42,3 +42,14 @@ WORKDIR /work
 # We can switch to that when it becomes stable.
 COPY Toolchain.cmake /usr/lib/${CROSS_TRIPLE}/
 ENV CMAKE_TOOLCHAIN_FILE /usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/linux-x64/Dockerfile
+++ b/linux-x64/Dockerfile
@@ -15,3 +15,14 @@ COPY ${CROSS_TRIPLE}-noop.sh /usr/bin/${CROSS_TRIPLE}-noop
 COPY Toolchain.cmake /usr/lib/${CROSS_TRIPLE}/
 ENV CMAKE_TOOLCHAIN_FILE /usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
 ENV DEFAULT_DOCKCROSS_IMAGE dockcross/linux-x64
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/linux-x86/Dockerfile
+++ b/linux-x86/Dockerfile
@@ -43,3 +43,14 @@ ENV CMAKE_TOOLCHAIN_FILE /usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
 
 COPY linux32-entrypoint.sh /dockcross/
 ENTRYPOINT ["/dockcross/linux32-entrypoint.sh"]
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/manylinux-x64/Dockerfile.in
+++ b/manylinux-x64/Dockerfile.in
@@ -28,3 +28,14 @@ COPY linux-x64/${CROSS_TRIPLE}-noop.sh /usr/bin/${CROSS_TRIPLE}-noop
 COPY manylinux-x64/Toolchain.cmake ${CROSS_ROOT}/../lib/
 ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/../lib/Toolchain.cmake
 ENV DEFAULT_DOCKCROSS_IMAGE dockcross/manylinux-x64
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/manylinux-x86/Dockerfile.in
+++ b/manylinux-x86/Dockerfile.in
@@ -36,3 +36,14 @@ RUN curl -O https://cmake.org/files/v3.6/cmake-3.6.2-Linux-i386.tar.gz && \
 
 COPY linux-x86/linux32-entrypoint.sh /dockcross/
 ENTRYPOINT ["/dockcross/linux32-entrypoint.sh"]
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/windows-x64/Dockerfile
+++ b/windows-x64/Dockerfile
@@ -70,3 +70,14 @@ WORKDIR /work
 
 ENV CMAKE_TOOLCHAIN_FILE /usr/src/mxe/usr/x86_64-w64-mingw32.static/share/cmake/mxe-conf.cmake
 RUN echo 'set(CMAKE_CROSSCOMPILING_EMULATOR "/usr/bin/wine")' >> ${CMAKE_TOOLCHAIN_FILE}
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/windows-x86/Dockerfile
+++ b/windows-x86/Dockerfile
@@ -70,3 +70,14 @@ WORKDIR /work
 
 ENV CMAKE_TOOLCHAIN_FILE /usr/src/mxe/usr/i686-w64-mingw32.static/share/cmake/mxe-conf.cmake
 RUN echo 'set(CMAKE_CROSSCOMPILING_EMULATOR "/usr/bin/wine")' >> ${CMAKE_TOOLCHAIN_FILE}
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"


### PR DESCRIPTION
This commit build each images with the following arguments:
- IMAGE: Name of the image (e.g dockcross/base, dockcross/manylinux-x64, ...)
- VCS_REF: dockcross/dockcross commit from which this image is built
- VCS_URL: this repository obtained reading remote.origin.url
- BUILD_DATE: Date and time when the build was initiated

Then, within the Dockerfile, the metadata are associated with the image
using the "LABEL" instruction.
See https://docs.docker.com/engine/reference/builder/#/label

The corresponding labels can be found here:
http://label-schema.org/rc1/#build-time-labels

See #28
