### PR TITLE
dockcross: Ignore deletion error when running in unprivileged LXC container

### DIFF
--- a/imagefiles/dockcross
+++ b/imagefiles/dockcross
@@ -180,11 +180,16 @@ fi
 # Now, finally, run the command in a container
 #
 tty -s && TTY_ARGS=-ti || TTY_ARGS=
-docker run $TTY_ARGS --rm \
+CONTAINER_NAME=dockcross
+docker run $TTY_ARGS --name $CONTAINER_NAME \
     -v $PWD:/work \
     $USER_IDS \
     $FINAL_ARGS \
     $FINAL_IMAGE "$@"
+
+docker rm -f $CONTAINER_NAME > /dev/null && \
+  echo "Successfull removed container: $CONTAINER_NAME" || \
+  (echo "Failed to remove container: Ignoring error" && true)
 
 ################################################################################
 #

--- a/imagefiles/dockcross
+++ b/imagefiles/dockcross
@@ -180,7 +180,7 @@ fi
 # Now, finally, run the command in a container
 #
 tty -s && TTY_ARGS=-ti || TTY_ARGS=
-CONTAINER_NAME=dockcross
+CONTAINER_NAME=dockcross_$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 7 | head -n 1)
 docker run $TTY_ARGS --name $CONTAINER_NAME \
     -v $PWD:/work \
     $USER_IDS \

--- a/imagefiles/dockcross
+++ b/imagefiles/dockcross
@@ -187,9 +187,7 @@ docker run $TTY_ARGS --name $CONTAINER_NAME \
     $FINAL_ARGS \
     $FINAL_IMAGE "$@"
 
-docker rm -f $CONTAINER_NAME > /dev/null && \
-  echo "Successfull removed container: $CONTAINER_NAME" || \
-  (echo "Failed to remove container: Ignoring error" && true)
+docker rm -f $CONTAINER_NAME > /dev/null || true
 
 ################################################################################
 #

--- a/imagefiles/dockcross
+++ b/imagefiles/dockcross
@@ -186,8 +186,14 @@ docker run $TTY_ARGS --name $CONTAINER_NAME \
     $USER_IDS \
     $FINAL_ARGS \
     $FINAL_IMAGE "$@"
+run_exit_code=$?
 
+# Deleting the container while ignoring error is required because of
+# https://circleci.com/docs/docker-btrfs-error/.
+# See issue dockcross/dockcross#50 for more details.
 docker rm -f $CONTAINER_NAME > /dev/null || true
+
+exit $run_exit_code
 
 ################################################################################
 #

--- a/imagefiles/dockcross
+++ b/imagefiles/dockcross
@@ -180,7 +180,7 @@ fi
 # Now, finally, run the command in a container
 #
 tty -s && TTY_ARGS=-ti || TTY_ARGS=
-CONTAINER_NAME=dockcross_$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 7 | head -n 1)
+CONTAINER_NAME=dockcross_$(cat /dev/urandom | base64 | tr -dc 'a-zA-Z0-9' | fold -w 7 | head -n 1)
 docker run $TTY_ARGS --name $CONTAINER_NAME \
     -v $PWD:/work \
     $USER_IDS \


### PR DESCRIPTION
This commit workarounds the problem described in [1] and [2] by ignoring error
happening when deleting container in unprivileged LXC container.

Fixes #50

[1] https://circleci.com/docs/docker-btrfs-error/
[2] https://discuss.circleci.com/t/docker-error-removing-intermediate-container/70