### PR TITLE
dockcross: Prevent dockcross from blocking when used with Python subprocess

### DIFF
--- a/imagefiles/dockcross
+++ b/imagefiles/dockcross
@@ -180,7 +180,7 @@ fi
 # Now, finally, run the command in a container
 #
 tty -s && TTY_ARGS=-ti || TTY_ARGS=
-CONTAINER_NAME=dockcross_$(cat /dev/urandom | base64 | tr -dc 'a-zA-Z0-9' | fold -w 7 | head -n 1)
+CONTAINER_NAME=dockcross_$(head -c 500 /dev/urandom | base64 | tr -dc 'a-zA-Z0-9' | fold -w 7 | head -n 1)
 docker run $TTY_ARGS --name $CONTAINER_NAME \
     -v $PWD:/work \
     $USER_IDS \

--- a/imagefiles/dockcross
+++ b/imagefiles/dockcross
@@ -180,7 +180,7 @@ fi
 # Now, finally, run the command in a container
 #
 tty -s && TTY_ARGS=-ti || TTY_ARGS=
-CONTAINER_NAME=dockcross_$(head -c 500 /dev/urandom | base64 | tr -dc 'a-zA-Z0-9' | fold -w 7 | head -n 1)
+CONTAINER_NAME=dockcross_$RANDOM
 docker run $TTY_ARGS --name $CONTAINER_NAME \
     -v $PWD:/work \
     $USER_IDS \


### PR DESCRIPTION
As explained in [1], when using dockcross from python subprocess, the
interactive mode is disabled and output of `cat /dev/urandom` is _block
buffered_ instead of being _line buffered_.

Workaround to this problem is to simply read a fixed amount of characters
from urandom.

The following two snippets illustrates the problem and the
the implemented  solution:

Works

``` python
import subprocess as sp
sp.check_call("var=$(head -c 500 /dev/urandom | base64 | tr -dc 'a-zA-Z0-9' | fold -w 7 | head -n 1); echo $var", shell=True)
```

=> output random string

Fail:

``` python
import subprocess as sp
sp.check_call("var=$(cat /dev/urandom | base64 | tr -dc 'a-zA-Z0-9' | fold -w 7 | head -n 1); echo $var", shell=True)
```

=> Hang

[1] http://stackoverflow.com/questions/16805827/unable-to-read-stdout-from-a-running-process#16806506
