### PR TITLE
base: Bump CMake for improved add_custom_command

### DIFF
--- a/common.docker
+++ b/common.docker
@@ -5,10 +5,20 @@ RUN git clone "https://github.com/nojhan/liquidprompt.git" && \
 COPY imagefiles/.bashrc /root/
 
 WORKDIR /usr/src
-RUN curl -O https://cmake.org/files/v3.6/cmake-3.6.2-Linux-x86_64.tar.gz && \
-   tar xzf cmake-3.6.2-Linux-x86_64.tar.gz && \
-   cp -a cmake-3.6.2-Linux-x86_64/* /usr/ && \
-   rm -rf cmake-3.6.2-Linux-x86_64
+RUN git clone git://cmake.org/cmake.git CMake && \
+  cd CMake && \
+  git checkout ab2ae4823c3b60347825da4b851cd4e676f8bed1 && \
+  mkdir /usr/src/CMake-build && \
+  cd /usr/src/CMake-build && \
+  /usr/src/CMake/bootstrap \
+    --parallel=$(grep -c processor /proc/cpuinfo) \
+    --prefix=/usr && \
+  make -j$(grep -c processor /proc/cpuinfo) && \
+  ./bin/cmake \
+    -DCMAKE_BUILD_TYPE:STRING=Release \
+    -DCMAKE_USE_OPENSSL:BOOL=ON . && \
+  make install && \
+  cd .. && rm -rf CMake*
 
 RUN git clone "https://github.com/martine/ninja.git" && \
    cd ninja && \


### PR DESCRIPTION
Improves cross-compilation support in add_custom_command by integrating

  https://gitlab.kitware.com/cmake/cmake/merge_requests/217

CMake Git master from 2016-11-03 (3.8-master).

Addresses #54