### PR TITLE
dockcross: Ensure deletion error are ignored

### DIFF
--- a/imagefiles/dockcross
+++ b/imagefiles/dockcross
@@ -191,7 +191,7 @@ run_exit_code=$?
 # Deleting the container while ignoring error is required because of
 # https://circleci.com/docs/docker-btrfs-error/.
 # See issue dockcross/dockcross#50 for more details.
-docker rm -f $CONTAINER_NAME > /dev/null || true
+docker rm -f $CONTAINER_NAME > /dev/null 2>&1 || true
 
 exit $run_exit_code
 


### PR DESCRIPTION
This commit follows up on 2e71db2 (dockcross: Ignore deletion error
when running in unprivileged LXC container) by also redirecting stderr
to /dev/null

Doing so will avoid adding "noise" to log of service like CircleCI
that are effectively running docker in unprivileged LXC container.

The down side is that, legitimate deletion errors will also be captured.