### PR TITLE
manylinux.common: Fix warning changing ownership of python install

### DIFF
--- a/common.manylinux
+++ b/common.manylinux
@@ -7,6 +7,8 @@ RUN cd /opt && \
 COPY manylinux-common/install-python-packages.sh /usr/local/bin
 RUN /usr/local/bin/install-python-packages.sh
 
+COPY manylinux-common/pre_exec.sh /dockcross/pre_exec.sh
+
 RUN yum -y install sudo && \
   sed -i 's/Defaults    requiretty/#Defaults    requiretty/' /etc/sudoers && \
   visudo -c

--- a/imagefiles/entrypoint.sh
+++ b/imagefiles/entrypoint.sh
@@ -31,6 +31,11 @@ if [[ -n $BUILDER_UID ]] && [[ -n $BUILDER_GID ]]; then
     cp -r /root/* $HOME/
     chown -R $BUILDER_UID:$BUILDER_GID $HOME/*
 
+    # Additional updates specific to the image
+    if [[ -e /dockcross/pre_exec.sh ]]; then
+        /dockcross/pre_exec.sh
+    fi
+
     # Run the command as the specified user/group.
     exec chpst -u :$BUILDER_UID:$BUILDER_GID "$@"
 else

--- a/manylinux-common/pre_exec.sh
+++ b/manylinux-common/pre_exec.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+for DIR in /opt/python/*/lib/python*/site-packages; do
+  chown -R $BUILDER_UID:$BUILDER_GID $DIR
+done
+for DIR in /opt/python/*/bin; do
+  chown -R $BUILDER_UID:$BUILDER_GID $DIR
+done


### PR DESCRIPTION
While the use of sudo (made possible by 53cf084) allows to install
additional packages, the warning copied below was still reported.

To avoid this warning and streamline the installation of new packages,
this commit (1) introduces the concept of "pre_exec" entrypoint hook
and (2) adds such a hook to change the ownership of python "bin" and
"site-packages" directories for the manylinux images.

Warning reported are similar to this one:

```
The directory '/home/jcfr/.cache/pip/http' or its parent directory is
not owned by the current user and the cache has been disabled. Please
check the permissions and owner of that directory. If executing pip
with sudo, you may want sudo's -H flag.
```

Note that the sudo "-H" flag suggested in the warning is not available
in centos.