### PR TITLE
common.docker: Ensure openssl-1.0.2j is available in manylinux and linux images

### DIFF
--- a/common.docker
+++ b/common.docker
@@ -5,13 +5,20 @@ RUN git clone "https://github.com/nojhan/liquidprompt.git" && \
 COPY imagefiles/.bashrc /root/
 
 WORKDIR /usr/src
+
+
 RUN wget https://www.openssl.org/source/openssl-1.0.2j.tar.gz && \
   tar -xzvf openssl-1.0.2j.tar.gz && \
   cd openssl-1.0.2j && \
   WRAPPER=$( [ $DEFAULT_DOCKCROSS_IMAGE = "dockcross/manylinux-x86" ] && echo "linux32" || echo "") && \
   CONFIG_FLAG=$( [ $DEFAULT_DOCKCROSS_IMAGE = "dockcross/manylinux-x86" ] && echo "-m32" || echo "") && \
-  ${WRAPPER} ./config $CONFIG_FLAG && \
+  ${WRAPPER} ./config --prefix=/usr $CONFIG_FLAG && \
   ${WRAPPER} make && \
+  ( \
+    ( echo $DEFAULT_DOCKCROSS_IMAGE | grep -E "linux-x(86|64)" ) && \
+    ${WRAPPER} make install || \
+    echo "Skipping OpenSSL installation" \
+  ) && \
   cd .. && \
   git clone git://cmake.org/cmake.git CMake && \
   cd CMake && \


### PR DESCRIPTION
If images are any of manylinux-x86, manylinux-x64, linux-x86 or linux-x64,
OpenSSL libraries are installed in /usr .