### PR TITLE
[many]linux-(x86|x64)/: toolchain: Fix ASM compiler

### DIFF
--- a/linux-x64/Toolchain.cmake
+++ b/linux-x64/Toolchain.cmake
@@ -6,6 +6,6 @@ set(cross_triple "x86_64-linux-gnu")
 
 set(CMAKE_C_COMPILER /usr/bin/${cross_triple}-gcc)
 set(CMAKE_CXX_COMPILER /usr/bin/${cross_triple}-g++)
-set(CMAKE_ASM_COMPILER /usr/bin/${cross_triple}-as)
+set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
 
 set(CMAKE_CROSSCOMPILING_EMULATOR /usr/bin/${cross_triple}-noop)

--- a/manylinux-x64/Toolchain.cmake
+++ b/manylinux-x64/Toolchain.cmake
@@ -6,7 +6,7 @@ set(cross_triple "x86_64-linux-gnu")
 
 set(CMAKE_C_COMPILER /opt/rh/devtoolset-2/root/usr/bin/gcc)
 set(CMAKE_CXX_COMPILER /opt/rh/devtoolset-2/root/usr/bin/g++)
-set(CMAKE_ASM_COMPILER /opt/rh/devtoolset-2/root/usr/bin/as)
+set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
 set(CMAKE_Fortran_COMPILER /opt/rh/devtoolset-2/root/usr/bin/gfortran)
 
 set(CMAKE_CROSSCOMPILING_EMULATOR /usr/bin/${cross_triple}-noop)

--- a/manylinux-x86/Toolchain.cmake
+++ b/manylinux-x86/Toolchain.cmake
@@ -6,7 +6,7 @@ set(cross_triple "i686-linux-gnu")
 
 set(CMAKE_C_COMPILER /opt/rh/devtoolset-2/root/usr/bin/gcc)
 set(CMAKE_CXX_COMPILER /opt/rh/devtoolset-2/root/usr/bin/g++)
-set(CMAKE_ASM_COMPILER /opt/rh/devtoolset-2/root/usr/bin/as)
+set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
 set(CMAKE_Fortran_COMPILER /opt/rh/devtoolset-2/root/usr/bin/gfortran)
 
 # Discard path returned by pkg-config and associated with HINTS in module


### PR DESCRIPTION
Similarly to the linux-x86 toolchain, gcc is used to compile assembler
file.