### PR TITLE
common.docker: Improve OpenSSL and CMake install introducing helper scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ bin
 dockcross
 */test/
 Dockerfile
+*/install-openssl.sh
+!imagefiles/install-openssl.sh

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -15,8 +15,6 @@ RUN apt-get update && apt-get -y install \
   file \
   git \
   gzip \
-  libcurl4-openssl-dev \
-  libssl-dev \
   make \
   ncurses-dev \
   pkg-config \

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ $(VERBOSE).SILENT: display_images
 # build implicit rule
 #
 $(STANDARD_IMAGES): base
+	cp imagefiles/install-openssl.sh $@/
 	$(DOCKER) build -t $(ORG)/$@ \
 		--build-arg IMAGE=$(ORG)/$@ \
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \

--- a/common.docker
+++ b/common.docker
@@ -6,36 +6,16 @@ COPY imagefiles/.bashrc /root/
 
 WORKDIR /usr/src
 
-
-RUN wget https://www.openssl.org/source/openssl-1.0.2j.tar.gz && \
-  tar -xzvf openssl-1.0.2j.tar.gz && \
-  cd openssl-1.0.2j && \
-  WRAPPER=$( [ "$DEFAULT_DOCKCROSS_IMAGE" = "dockcross/manylinux-x86" ] && echo "linux32" || echo "") && \
-  CONFIG_FLAG=$( [ "$DEFAULT_DOCKCROSS_IMAGE" = "dockcross/manylinux-x86" ] && echo "-m32" || echo "") && \
-  ${WRAPPER} ./config --prefix=/usr $CONFIG_FLAG && \
-  ${WRAPPER} make && \
-  ( \
-    ( echo $DEFAULT_DOCKCROSS_IMAGE | grep -E "linux-x(86|64)" ) && \
-    ${WRAPPER} make install || \
-    echo "Skipping OpenSSL installation" \
-  ) && \
-  cd .. && \
-  git clone git://cmake.org/cmake.git CMake && \
-  cd CMake && \
-  git checkout ab2ae4823c3b60347825da4b851cd4e676f8bed1 && \
-  mkdir /usr/src/CMake-build && \
-  cd /usr/src/CMake-build && \
-  ${WRAPPER} /usr/src/CMake/bootstrap \
-    --parallel=$(grep -c processor /proc/cpuinfo) \
-    --prefix=/usr && \
-  ${WRAPPER} make -j$(grep -c processor /proc/cpuinfo) && \
-  ${WRAPPER} ./bin/cmake \
-    -DCMAKE_BUILD_TYPE:STRING=Release \
-    -DCMAKE_USE_OPENSSL:BOOL=ON \
-    -DOPENSSL_ROOT_DIR:PATH=/usr/src/openssl-1.0.2j \
-    . && \
-  ${WRAPPER} make install && \
-  cd .. && rm -rf CMake* && rm -rf /usr/src/openssl-1.0.2j*
+COPY imagefiles/install-openssl.sh imagefiles/install-cmake.sh /dockcross/
+RUN \
+  if [ "$DEFAULT_DOCKCROSS_IMAGE" = "dockcross/manylinux-x86" ]; then \
+    /dockcross/install-openssl.sh -32 && \
+    /dockcross/install-cmake.sh -32 || exit 1; \
+  else \
+    /dockcross/install-openssl.sh && \
+    /dockcross/install-cmake.sh || exit 1; \
+  fi; \
+  rm /dockcross/install-openssl.sh /dockcross/install-cmake.sh
 
 RUN git clone "https://github.com/ninja-build/ninja.git" && \
    cd ninja && \

--- a/imagefiles/install-cmake.sh
+++ b/imagefiles/install-cmake.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+#
+# Configure, build and install CMake
+#
+# Usage:
+#
+#  install-cmake.sh [-32]
+#
+# Options:
+#
+#  -32                 Build CMake as a 32-bit executable
+#
+# Notes:
+#
+#  * build directory is /usr/src/CMake
+#
+#  * install directory is /usr
+#
+#  * after installation, archive, source and build directories are removed
+#
+
+set -e
+set -o pipefail
+
+WRAPPER=""
+CONFIG_FLAG=""
+SUFFIX=64
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -32)
+      WRAPPER="linux32"
+      CONFIG_FLAG="-m32"
+      SUFFIX=32
+      ;;
+    *)
+      echo "Usage: Usage: ${0##*/} [-32]"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+cd /usr/src
+
+# Download
+CMAKE_REV=ab2ae4823c3b60347825da4b851cd4e676f8bed1
+wget https://github.com/kitware/cmake/archive/$CMAKE_REV.tar.gz -O CMake.tar.gz
+mkdir CMake
+tar -xzvf ./CMake.tar.gz --strip-components=1 -C ./CMake
+
+mkdir /usr/src/CMake-build
+
+pushd /usr/src/CMake-build
+
+NUM_PROCESSOR=$(grep -c processor /proc/cpuinfo)
+
+# Configure boostrap
+${WRAPPER} /usr/src/CMake/bootstrap \
+  --parallel=$NUM_PROCESSOR \
+  --prefix=/usr
+
+# Build and Install
+${WRAPPER} make install -j$NUM_PROCESSOR
+
+# Test
+ctest -R CMake.FileDownload
+
+# Write test script
+cat <<EOF > cmake-test-https-download.cmake
+
+file(
+  DOWNLOAD https://raw.githubusercontent.com/Kitware/CMake/master/README.rst /tmp/README.rst
+  STATUS status
+  )
+list(GET status 0 error_code)
+list(GET status 1 error_msg)
+if(error_code)
+  message(FATAL_ERROR "error: Failed to download ${url} - ${error_msg}")
+else()
+  message(STATUS "CMake: HTTPS download works")
+endif()
+
+file(REMOVE /tmp/README.rst)
+
+EOF
+
+# Execute test script
+cmake -P cmake-test-https-download.cmake
+rm cmake-test-https-download.cmake
+
+popd
+
+rm -rf CMake*

--- a/imagefiles/install-openssl.sh
+++ b/imagefiles/install-openssl.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+#
+# Configure, build and install OpenSSL
+#
+# Usage:
+#
+#  install-openssl.sh [-32]
+#
+# Options:
+#
+#  -32              Build OpenSSL as a 32-bit library
+#
+# Notes:
+#
+#  * build directory is /usr/src/openssl-$OPENSSL_VERSION
+#
+#  * install directory is /usr
+#
+#  * after installation, build directory and archive are removed
+#
+
+set -e
+set -o pipefail
+
+WRAPPER=""
+CONFIG_FLAG="-fPIC"
+SUFFIX=64
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -32)
+      WRAPPER="linux32"
+      CONFIG_FLAG="-m32"
+      SUFFIX=32
+      ;;
+    *)
+      echo "Usage: Usage: ${0##*/} [-32]"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+OPENSSL_VERSION=1.0.2j
+OPENSSL_SHA256=e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431
+
+cd /usr/src
+
+# Download
+if [ ! -f ./openssl-$OPENSSL_VERSION.tar.gz ]; then
+  wget https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz
+else
+  rm -rf ./openssl-$OPENSSL_VERSION
+fi
+
+# Verify
+sha256_openssl=`sha256sum ./openssl-$OPENSSL_VERSION.tar.gz | awk '{ print $1 }'`
+if [ "$sha256_openssl" != "$OPENSSL_SHA256" ]
+then
+  echo "SHA256 mismatch. Problem downloading OpenSSL."
+  echo "  current [$sha256_openssl]"
+  echo "  expected[$OPENSSL_SHA256]"
+  exit 1
+fi
+
+# Extract
+tar -xzvf openssl-$OPENSSL_VERSION.tar.gz
+
+pushd openssl-$OPENSSL_VERSION
+
+# Configure
+${WRAPPER} ./config --prefix=/usr $CONFIG_FLAG
+
+# Build & Install
+${WRAPPER} make install
+
+popd
+
+# Clean
+rm -rf ./openssl-$OPENSSL_VERSION*
+rm -rf /usr/ssl/man
+

--- a/linux-x86/Dockerfile
+++ b/linux-x86/Dockerfile
@@ -9,8 +9,7 @@ RUN dpkg --add-architecture i386 && \
     libstdc++6:i386 \
     libbz2-dev:i386 \
     libexpat1-dev:i386 \
-    ncurses-dev:i386 \
-    libssl-dev:i386
+    ncurses-dev:i386
 
 ENV CROSS_TRIPLE i686-linux-gnu
 ENV CROSS_ROOT /usr/${CROSS_TRIPLE}
@@ -33,6 +32,12 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
     CXX=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-g++
+
+
+COPY install-openssl.sh /dockcross/
+RUN \
+  /dockcross/install-openssl.sh -32 && \
+  rm /dockcross/install-openssl.sh
 
 ENV DEFAULT_DOCKCROSS_IMAGE dockcross/linux-x86
 


### PR DESCRIPTION
To accommodate the requirements associated with x86 and x64 images, the
command building OpenSSL and CMake became overly complex and hard to
maintain.

This commit has multiple purposes:

(1) simplify common.docker

(2) fix the building of 64-bit shared libraries against the static openssl
libraries by passing the -fPIC flag.

(3) ensure [many]linux-x86 and [many]linux-x64 images have an up-to-date
OpenSSL install. Openssl static libraries are installed in /usr

(4) simplify and speedup CMake build avoiding the second build with
explicit -DCMAKE_USE_OPENSSL:BOOL=ON. Indeed, configuring CMake on Linux
already looks for OpenSSL.

(5) speedup download of CMake source directly downloading the archive
corresponding to the revision.

(6) test CMake by:
  - running CMake.FileDownload test
  - trying to download a file served over https