### PR TITLE
base: Optimize image build adding only image and vcs_url metatdata

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -34,12 +34,10 @@ RUN apt-get update && apt-get -y install \
 #include "common.docker"
 
 # Build-time metadata as defined at http://label-schema.org
-ARG BUILD_DATE
+# Note: To avoid systematic rebuild of dependent images, only
+#       name and vcs-url are included.
 ARG IMAGE
-ARG VCS_REF
 ARG VCS_URL
-LABEL org.label-schema.build-date=$BUILD_DATE \
-      org.label-schema.name=$IMAGE \
-      org.label-schema.vcs-ref=$VCS_REF \
+LABEL org.label-schema.name=$IMAGE \
       org.label-schema.vcs-url=$VCS_URL \
       org.label-schema.schema-version="1.0"

--- a/Makefile
+++ b/Makefile
@@ -98,9 +98,7 @@ Dockerfile: Dockerfile.in common.docker
 base: Dockerfile imagefiles/
 	$(DOCKER) build -t $(ORG)/base \
 		--build-arg IMAGE=$(ORG)/base \
-		--build-arg VCS_REF=`git rev-parse --short HEAD` \
 		--build-arg VCS_URL=`git config --get remote.origin.url` \
-		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
 		.
 
 base.test: base


### PR DESCRIPTION
To avoid dependent images to systematically rebuild, this commit
adds only "static" metatdata to the base image