### PR TITLE
common.docker: Set global git config "advice.detachedHead" to "false"

### DIFF
--- a/common.docker
+++ b/common.docker
@@ -26,6 +26,8 @@ RUN \
     -python $([ -e /opt/python/cp35-cp35m/bin/python ] && echo "/opt/python/cp35-cp35m/bin/python" || echo "python") && \
   rm /dockcross/install-ninja.sh
 
+RUN git config --global advice.detachedHead false
+
 RUN echo "root:root" | chpasswd
 WORKDIR /work
 ENTRYPOINT ["/dockcross/entrypoint.sh"]


### PR DESCRIPTION
This will avoid warnings like this one when building project
using CMake ExternalProject:
```
  Cloning into 'XYZ'...
  Note: checking out 'abcdef...'.

  You are in 'detached HEAD' state. You can look around, make experimental
  changes and commit them, and you can discard any commits you make in this
  state without impacting any branches by performing another checkout.

  If you want to create a new branch to retain commits you create, you may
  do so (now or later) by using -b with the checkout command again. Example:

    git checkout -b new_branch_name

  HEAD is now at abcdef... Foo bar.
```