### PR TITLE
Makefile: Fix tests removing double quote from RM variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,9 @@ windows-x64.test_ARGS = --exe-suffix ".exe"
 
 # On CircleCI, do not attempt to delete container
 # See https://circleci.com/docs/docker-btrfs-error/
-RM = "--rm"
+RM = --rm
 ifeq ("$(CIRCLECI)", "true")
-	RM = ""
+	RM =
 endif
 
 #


### PR DESCRIPTION
This commit fixes a regression introduced in 6823cb1 (Makefile: Do not
specify "--rm" docker run argument when executing on CircleCI)