### PR TITLE
common: add bc package

### DIFF
--- a/common.debian
+++ b/common.debian
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get -y install \
   autogen \
   bash \
   build-essential \
+  bc \
   bzip2 \
   ca-certificates \
   curl \


### PR DESCRIPTION
The ``bc`` utility is required to build the 4.x Linux kernel series as described [here](https://www.kernel.org/doc/Documentation/Changes).
This change installs the ``bc`` package when creating the dockcross base image.

Testing: built all docker images, built latest stable Linux kernel 4.8.11, happyness.