### PR TITLE
dockcross: Check if "/proc/version" exists and fix error on MacOSX. Fixes #94

### DIFF
--- a/imagefiles/dockcross
+++ b/imagefiles/dockcross
@@ -172,9 +172,9 @@ fi
 FINAL_ARGS=${ARG_ARGS-${DOCKCROSS_ARGS}}
 
 # Bash on Ubuntu on Windows
-UBUNTU_ON_WINDOWS=$(grep -l Microsoft /proc/version)
+UBUNTU_ON_WINDOWS=$([ -e /proc/version ] && grep -l Microsoft /proc/version || echo "")
 # MSYS, Git Bash, etc.
-MSYS=$(grep -l MINGW /proc/version)
+MSYS=$([ -e /proc/version ] && grep -l MINGW /proc/version || echo "")
 
 if [ -z "$UBUNTU_ON_WINDOWS" -a -z "$MSYS" ]; then
     USER_IDS="-e BUILDER_UID=$( id -u ) -e BUILDER_GID=$( id -g ) -e BUILDER_USER=$( id -un ) -e BUILDER_GROUP=$( id -gn )"


### PR DESCRIPTION
This commit will avoid the following error from being reported
on MacOSX:

```
docker run --rm dockcross/linux-armv7 > ./dockcross-linux-armv7
chmod +x ./dockcross-linux-armv7
./dockcross-linux-armv7 bash -c '$CC test/C/hello.c -o hello_arm'
grep: /proc/version: No such file or directory
grep: /proc/version: No such file or directory
```

Reported-by: Chris Warth <cswarth@gmail.com>