### PR TITLE
manylinux-common: Fix pip install change ownership of "man" and "share" dir

### DIFF
--- a/manylinux-common/pre_exec.sh
+++ b/manylinux-common/pre_exec.sh
@@ -6,3 +6,10 @@ done
 for DIR in /opt/python/*/bin; do
   chown -R $BUILDER_UID:$BUILDER_GID $DIR
 done
+for DIR in /opt/python/*; do
+  mkdir $DIR/man
+  chown -R $BUILDER_UID:$BUILDER_GID $DIR/man
+done
+for DIR in /opt/python/*/share; do
+  chown -R $BUILDER_UID:$BUILDER_GID $DIR
+done


### PR DESCRIPTION
This commit will fix installation of packages like nose that would otherwise
fail to install with error like the following:

  Installing collected packages: nose
  Exception:
  Traceback (most recent call last):
  [...]
  Permission denied: '/opt/_internal/cpython-2.7.11-ucs2/man'