### PR TITLE
SSH Support for Git Clone / Checkout

### DIFF
--- a/common.debian
+++ b/common.debian
@@ -24,6 +24,7 @@ RUN apt-get update --yes && apt-get install --no-install-recommends --yes \
   python-pip \
   rsync \
   sed \
+  ssh \
   bison \
   flex \
   tar \

--- a/common.manylinux
+++ b/common.manylinux
@@ -23,5 +23,5 @@ RUN /usr/local/bin/install-python-packages.sh
 
 COPY manylinux-common/pre_exec.sh /dockcross/pre_exec.sh
 
-RUN yum -y install pax zip \
+RUN yum -y install pax zip openssh-clients \
   && yum clean all

--- a/imagefiles/dockcross
+++ b/imagefiles/dockcross
@@ -193,6 +193,16 @@ else
     HOST_PWD=$PWD
 fi
 
+# Mount Additional Volumes
+if [ -z "$SSH_DIR" ]; then
+    SSH_DIR="$HOME/.ssh"
+fi
+
+HOST_VOLUMES=
+if [ -e "$SSH_DIR" ]; then
+    HOST_VOLUMES+="-v $SSH_DIR:/home/$(id -un)/.ssh"
+fi
+
 #------------------------------------------------------------------------------
 # Now, finally, run the command in a container
 #
@@ -200,6 +210,7 @@ tty -s && TTY_ARGS=-ti || TTY_ARGS=
 CONTAINER_NAME=dockcross_$RANDOM
 docker run $TTY_ARGS --name $CONTAINER_NAME \
     -v "$HOST_PWD":/work \
+    $HOST_VOLUMES \
     $USER_IDS \
     $FINAL_ARGS \
     $FINAL_IMAGE "$@"


### PR DESCRIPTION
Added SSH support to enable Git checkouts that use SSH instead of
HTTP(S).

The SSH directory is assumed to be in $HOME/.ssh; however:

export SSH_DIR=/my/custom/dir

will override the setting and allow for configurable settings.

$SSH_DIR is then mounted as host-volume in the Docker container and
placed in /home/\<user\>/.ssh