### PR TITLE
circleci-matrix: Ensure errors trigger failure

### DIFF
--- a/.circleci-matrix.yml
+++ b/.circleci-matrix.yml
@@ -16,6 +16,7 @@ env:
   - IMAGE=windows-x86
 command:
   - |
+    set -e
     if [[ $STEP == "dependencies" ]]; then
       if [[ $CIRCLE_NODE_INDEX == 0 ]]; then
         if [[ ! -f ~/BASE_AVAILABLE ]]; then


### PR DESCRIPTION
PR#137 was expected to fail because of missing repo files, this PR should
ensure the build fail as expected.

Thanks: Constantine Grantcharov <cgrantcharov@trustpointinnovation.com>