### PR TITLE
linux-*: Change common.docker to fix pip installation.

### DIFF
--- a/common.docker
+++ b/common.docker
@@ -32,11 +32,11 @@ RUN if [ -e /opt/python/cp35-cp35m/bin/python ]; then \
     : nothing to do here since it is updated by manylinux-common/install-python-packages.sh ; \
   else \
     wget https://bootstrap.pypa.io/get-pip.py && \
-    python get-pip.py && \
+    python get-pip.py --ignore-installed && \
     rm get-pip.py || exit 1; \
   fi
 
-RUN $([ -e /opt/python/cp35-cp35m/bin/python ] && echo "/opt/python/cp35-cp35m/bin/python" || echo "python") -m pip install conan
+RUN $([ -e /opt/python/cp35-cp35m/bin/python ] && echo "/opt/python/cp35-cp35m/bin/python" || echo "python") -m pip install --ignore-installed conan
 
 RUN echo "root:root" | chpasswd
 WORKDIR /work

--- a/common.docker
+++ b/common.docker
@@ -28,6 +28,14 @@ RUN \
     -python $([ -e /opt/python/cp35-cp35m/bin/python ] && echo "/opt/python/cp35-cp35m/bin/python" || echo "python") && \
   rm /dockcross/install-ninja.sh
 
+RUN if [ -e /opt/python/cp35-cp35m/bin/python ]; then \
+    : nothing to do here since it is updated by manylinux-common/install-python-packages.sh ; \
+  else \
+    wget https://bootstrap.pypa.io/get-pip.py && \
+    python get-pip.py && \
+    rm get-pip.py || exit 1; \
+  fi
+
 RUN $([ -e /opt/python/cp35-cp35m/bin/python ] && echo "/opt/python/cp35-cp35m/bin/python" || echo "python") -m pip install conan
 
 RUN echo "root:root" | chpasswd


### PR DESCRIPTION
Hi,

Thanks for these useful images.

While I was using dockcross/linux-armv7 image, I've noticed pip is broken like below.  pip is broken just after conan installation.  This happens on all linux-* images since pip is broken at dockcross/base image.  This PR will fix it.  I've tested this modifications by `make base` and `make manylinux-x64`.
```
$ dockcross-linux-armv7 pip
Traceback (most recent call last):
  File "/usr/bin/pip", line 9, in <module>
    load_entry_point('pip==1.5.6', 'console_scripts', 'pip')()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 356, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2476, in load_entry_point
    return ep.load()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2190, in load
    ['__name__'])
  File "/usr/lib/python2.7/dist-packages/pip/__init__.py", line 74, in <module>
    from pip.vcs import git, mercurial, subversion, bazaar  # noqa
  File "/usr/lib/python2.7/dist-packages/pip/vcs/mercurial.py", line 9, in <module>
    from pip.download import path_to_url
  File "/usr/lib/python2.7/dist-packages/pip/download.py", line 25, in <module>
    from requests.compat import IncompleteRead
ImportError: cannot import name IncompleteRead
```