### PR TITLE
Fix $HOME directory ownership permissions

### DIFF
--- a/imagefiles/entrypoint.sh
+++ b/imagefiles/entrypoint.sh
@@ -27,7 +27,7 @@ if [[ -n $BUILDER_UID ]] && [[ -n $BUILDER_GID ]]; then
     export HOME=/home/${BUILDER_USER}
     shopt -s dotglob
     cp -r /root/* $HOME/
-    chown -R $BUILDER_UID:$BUILDER_GID $HOME/*
+    chown -R $BUILDER_UID:$BUILDER_GID $HOME
 
     # Additional updates specific to the image
     if [[ -e /dockcross/pre_exec.sh ]]; then


### PR DESCRIPTION
BUG:

Creating a new directory under /home/\<user\>/ from the /work folder does
not work. In fact, going into the home directory and trying to run mkdir
fails as well.

SOLUTION:

Turns out chown -R \<user\>:\<user\> was run on $HOME/* instead of on $HOME.
This means that /home/\<user\> was still under the ownership of root:root,
hence preventing any writes to non-root users.