### PR TITLE
Missing shift in dockcross -- command [args]

### DIFF
--- a/imagefiles/dockcross
+++ b/imagefiles/dockcross
@@ -98,6 +98,7 @@ while [[ $# != 0 ]]; do
     case $1 in
 
         --)
+            shift
             break
             ;;
 


### PR DESCRIPTION
Otherwise `--` is sent as the command...