### PR TITLE
bump cmake to v3.10.1

### DIFF
--- a/imagefiles/install-cmake.sh
+++ b/imagefiles/install-cmake.sh
@@ -45,7 +45,7 @@ done
 cd /usr/src
 
 # Download
-CMAKE_REV=v3.8.0
+CMAKE_REV=v3.10.1
 wget --progress=bar:force https://github.com/kitware/cmake/archive/$CMAKE_REV.tar.gz -O CMake.tar.gz
 mkdir CMake
 tar -xzvf ./CMake.tar.gz --strip-components=1 -C ./CMake


### PR DESCRIPTION
I'm trying to build [PyMesh](http://pymesh.readthedocs.io/en/latest/installation.html) on dockcross/manylinux-x64 and to get it done I need a newer version of CMake.

The following issue comes up in the PyMesh build: https://gitlab.kitware.com/cmake/cmake/issues/16509 and the fix was merged in v3.10: https://gitlab.kitware.com/cmake/cmake/merge_requests/1009