### PR TITLE
QuickFix for issue #186

### DIFF
--- a/imagefiles/dockcross
+++ b/imagefiles/dockcross
@@ -183,7 +183,7 @@ fi
 
 # Change the PWD when working in Docker on Windows
 if [ -n "$UBUNTU_ON_WINDOWS" ]; then
-    HOST_PWD=$PWD
+    HOST_PWD=`pwd -P`
     HOST_PWD=${HOST_PWD/\/mnt\//}
     HOST_PWD=${HOST_PWD/\//:\/}
 elif [ -n "$MSYS" ]; then


### PR DESCRIPTION
Changed Windows Subsystem for Linux's PWD to be the physical path rather than relative since windows cannot traverse a relative path inside the Linux subsystem.