### PR TITLE
Remove duplicated code from base image.

### DIFF
--- a/browser-asmjs/Dockerfile.in
+++ b/browser-asmjs/Dockerfile.in
@@ -20,8 +20,6 @@ ENV DEFAULT_DOCKCROSS_IMAGE dockcross/browser-asmjs
 
 ENV CMAKE_TOOLCHAIN_FILE /emsdk_portable/sdk/cmake/Modules/Platform/Emscripten.cmake
 
-RUN mkdir -p /emsdk_portable/.cache && chmod -R 777 /emsdk_portable/.cache*
-
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
 ARG IMAGE


### PR DESCRIPTION
Hi, I found a simple improvement for your image. 
https://github.com/asRIA/emscripten-docker/pull/16 creates $EM_DATA with cache and 777 permissions

**Context**
* Paths to folders: https://github.com/asRIA/emscripten-docker/blob/79343484f38dfbdea85235e752fb7f35c633f871/docker/trzeci/emscripten-slim/Dockerfile#L13-L16
* Change permission: https://github.com/asRIA/emscripten-docker/blob/79343484f38dfbdea85235e752fb7f35c633f871/docker/trzeci/emscripten-slim/Dockerfile#L183

------

BTW: If I may ask: Was it somehow required for you to put Emscripten folders to the `PATH`? 