### PR TITLE
Fix download of files using up-to-date "curl" instead of "wget"

### DIFF
--- a/common.debian
+++ b/common.debian
@@ -36,10 +36,10 @@ RUN apt-get update --yes && apt-get install --no-install-recommends --yes \
 
 ENV GOSU_VERSION 1.10
 RUN set -x \
-        && apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
+        && apt-get update && rm -rf /var/lib/apt/lists/* \
         && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
-        && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
-        && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
+        && curl -# -o /usr/local/bin/gosu -LO "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
+        && curl -# -o /usr/local/bin/gosu.asc -LO "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
         && export GNUPGHOME="$(mktemp -d)" \
         && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
         && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \

--- a/common.docker
+++ b/common.docker
@@ -31,7 +31,7 @@ RUN \
 RUN if [ -e /opt/python/cp35-cp35m/bin/python ]; then \
     : nothing to do here since it is updated by manylinux-common/install-python-packages.sh ; \
   else \
-    wget https://bootstrap.pypa.io/get-pip.py && \
+    curl -# -LO https://bootstrap.pypa.io/get-pip.py && \
     python get-pip.py --ignore-installed && \
     rm get-pip.py || exit 1; \
   fi

--- a/common.manylinux
+++ b/common.manylinux
@@ -1,10 +1,10 @@
 ENV GOSU_VERSION 1.10
 RUN set -x \
 	&& yum -y install epel-release \
-	&& yum -y install wget gpg \
+	&& yum -y install gpg \
 	&& dpkgArch=$(if test $(uname -m) = "x86_64"; then echo amd64; else echo i386; fi) \
-	&& wget -O /usr/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
-	&& wget -O /tmp/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
+	&& curl -o /usr/bin/gosu -LO "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
+	&& curl -o /tmp/gosu.asc -LO "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
 	&& gpg --batch --verify /tmp/gosu.asc /usr/bin/gosu \

--- a/imagefiles/install-cmake.sh
+++ b/imagefiles/install-cmake.sh
@@ -46,7 +46,7 @@ cd /usr/src
 
 # Download
 CMAKE_REV=v3.10.1
-wget --progress=bar:force https://github.com/kitware/cmake/archive/$CMAKE_REV.tar.gz -O CMake.tar.gz
+curl -# -o CMake.tar.gz -LO https://github.com/kitware/cmake/archive/$CMAKE_REV.tar.gz
 mkdir CMake
 tar -xzvf ./CMake.tar.gz --strip-components=1 -C ./CMake
 

--- a/imagefiles/install-crosstool-ng-toolchain.sh
+++ b/imagefiles/install-crosstool-ng-toolchain.sh
@@ -58,7 +58,7 @@ cd "${CTNG}"
 
 # Download and install the "crosstool-ng" source.
 REV=1.23.0
-wget --progress=bar:force \
+curl -# -LO \
   "https://github.com/crosstool-ng/crosstool-ng/archive/crosstool-ng-${REV}.tar.gz"
 tar -xf "crosstool-ng-${REV}.tar.gz"
 cd "crosstool-ng-crosstool-ng-${REV}"

--- a/imagefiles/install-ninja.sh
+++ b/imagefiles/install-ninja.sh
@@ -27,7 +27,7 @@ done
 
 # Download
 REV=v1.7.2
-wget --progress=bar:force https://github.com/ninja-build/ninja/archive/$REV.tar.gz -O ninja.tar.gz
+curl -# -o ninja.tar.gz -LO https://github.com/ninja-build/ninja/archive/$REV.tar.gz
 mkdir ninja
 tar -xzvf ./ninja.tar.gz --strip-components=1 -C ./ninja
 

--- a/imagefiles/install-openssl.sh
+++ b/imagefiles/install-openssl.sh
@@ -49,7 +49,7 @@ cd /usr/src
 
 # Download
 if [ ! -f ./openssl-$OPENSSL_VERSION.tar.gz ]; then
-  wget --progress=bar:force https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz
+  curl -# -LO https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz
 else
   rm -rf ./openssl-$OPENSSL_VERSION
 fi


### PR DESCRIPTION
In few images, curl is only tool that able to download from https
source requiring TLS 1.2

This should address failures for the manylinux images. See #210