### PR TITLE
entrypoint.sh: Account for image tag when updating help text

### DIFF
--- a/imagefiles/entrypoint.sh
+++ b/imagefiles/entrypoint.sh
@@ -11,7 +11,7 @@ if [[ $# == 0 ]]; then
         echo "DEFAULT_DOCKCROSS_IMAGE=$DEFAULT_DOCKCROSS_IMAGE"
         tail -n +4 /dockcross/dockcross |
           sed -e "s@dockcross\/linux\-armv7@${DEFAULT_DOCKCROSS_IMAGE}@g" |
-          sed -e "s@dockcross\-linux\-armv7@${DEFAULT_DOCKCROSS_IMAGE//\//-}@g"
+          sed -e "s@dockcross\-linux\-armv7@${DEFAULT_DOCKCROSS_IMAGE//[\/:]/-}@g"
     else
         cat /dockcross/dockcross
     fi


### PR DESCRIPTION
This commit is a follow up of b7028af (entrypoint.sh: Update help
text so that current image name is used)

It ensures that the suggested script in the help text doesn't include ":"
in its name.

Assuming DEFAULT_DOCKCROSS_IMAGE is set to "dockcross/imagename:latest"

Instead of suggesting:

```console
  [...]
  # docker run --rm dockcross/imagename:latest > dockcross-imagename:latest
  # chmod +x dockcross-imagename:latest
  [...]
```
it will now suggest

```console
  [...]
  # docker run --rm dockcross/imagename:latest > dockcross-imagename-latest
  # chmod +x dockcross-imagename-latest
  [...]
```

xref https://github.com/dockbuild/dockbuild/issues/30

[ci skip]