### PR TITLE
crossbuild-essential images: disable because of missing packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,17 +87,18 @@ jobs:
     steps:
       - restore_cache:
           key: base-assets-{{ .Revision }}
-      - run:
-         name: linux-arm64 build
-         no_output_timeout: 1.5h
-         command: |
-           docker load -i ~/docker/base.tar
-           make linux-arm64
-           docker save -o ~/docker/linux-arm64.tar dockcross/linux-arm64:latest
-      - run:
-         name: linux-arm64 test
-         command: |
-           make linux-arm64.test
+      # Image build currently broken. See #209
+      #- run:
+         #name: linux-arm64 build
+         #no_output_timeout: 1.5h
+         #command: |
+           #docker load -i ~/docker/base.tar
+           #make linux-arm64
+           #docker save -o ~/docker/linux-arm64.tar dockcross/linux-arm64:latest
+      #- run:
+         #name: linux-arm64 test
+         #command: |
+           #make linux-arm64.test
       - save_cache:
           key: linux-arm64-assets-{{ .Revision }}
           paths: ~/docker/linux-arm64.tar
@@ -106,17 +107,18 @@ jobs:
     steps:
       - restore_cache:
           key: base-assets-{{ .Revision }}
-      - run:
-         name: linux-armv5 build
-         no_output_timeout: 1.5h
-         command: |
-           docker load -i ~/docker/base.tar
-           make linux-armv5
-           docker save -o ~/docker/linux-armv5.tar dockcross/linux-armv5:latest
-      - run:
-         name: linux-armv5 test
-         command: |
-           make linux-armv5.test
+      # Image build currently broken. See #209
+      #- run:
+         #name: linux-armv5 build
+         #no_output_timeout: 1.5h
+         #command: |
+           #docker load -i ~/docker/base.tar
+           #make linux-armv5
+           #docker save -o ~/docker/linux-armv5.tar dockcross/linux-armv5:latest
+      #- run:
+         #name: linux-armv5 test
+         #command: |
+           #make linux-armv5.test
       - save_cache:
           key: linux-armv5-assets-{{ .Revision }}
           paths: ~/docker/linux-armv5.tar
@@ -144,17 +146,18 @@ jobs:
     steps:
       - restore_cache:
           key: base-assets-{{ .Revision }}
-      - run:
-         name: linux-armv7 build
-         no_output_timeout: 1.5h
-         command: |
-           docker load -i ~/docker/base.tar
-           make linux-armv7
-           docker save -o ~/docker/linux-armv7.tar dockcross/linux-armv7:latest
-      - run:
-         name: linux-armv7 test
-         command: |
-           make linux-armv7.test
+      # Image build currently broken. See #209
+      #- run:
+         #name: linux-armv7 build
+         #no_output_timeout: 1.5h
+         #command: |
+           #docker load -i ~/docker/base.tar
+           #make linux-armv7
+           #docker save -o ~/docker/linux-armv7.tar dockcross/linux-armv7:latest
+      #- run:
+         #name: linux-armv7 test
+         #command: |
+           #make linux-armv7.test
       - save_cache:
           key: linux-armv7-assets-{{ .Revision }}
           paths: ~/docker/linux-armv7.tar
@@ -163,17 +166,18 @@ jobs:
     steps:
       - restore_cache:
           key: base-assets-{{ .Revision }}
-      - run:
-         name: linux-mipsel build
-         no_output_timeout: 1.5h
-         command: |
-           docker load -i ~/docker/base.tar
-           make linux-mipsel
-           docker save -o ~/docker/linux-mipsel.tar dockcross/linux-mipsel:latest
-      - run:
-         name: linux-mipsel test
-         command: |
-           make linux-mipsel.test
+      # Image build currently broken. See #209
+      #- run:
+         #name: linux-mipsel build
+         #no_output_timeout: 1.5h
+         #command: |
+           #docker load -i ~/docker/base.tar
+           #make linux-mipsel
+           #docker save -o ~/docker/linux-mipsel.tar dockcross/linux-mipsel:latest
+      #- run:
+         #name: linux-mipsel test
+         #command: |
+           #make linux-mipsel.test
       - save_cache:
           key: linux-mipsel-assets-{{ .Revision }}
           paths: ~/docker/linux-mipsel.tar
@@ -201,17 +205,18 @@ jobs:
     steps:
       - restore_cache:
           key: base-assets-{{ .Revision }}
-      - run:
-         name: linux-ppc64le build
-         no_output_timeout: 1.5h
-         command: |
-           docker load -i ~/docker/base.tar
-           make linux-ppc64le
-           docker save -o ~/docker/linux-ppc64le.tar dockcross/linux-ppc64le:latest
-      - run:
-         name: linux-ppc64le test
-         command: |
-           make linux-ppc64le.test
+      # Image build currently broken. See #209
+      #- run:
+         #name: linux-ppc64le build
+         #no_output_timeout: 1.5h
+         #command: |
+           #docker load -i ~/docker/base.tar
+           #make linux-ppc64le
+           #docker save -o ~/docker/linux-ppc64le.tar dockcross/linux-ppc64le:latest
+      #- run:
+         #name: linux-ppc64le test
+         #command: |
+           #make linux-ppc64le.test
       - save_cache:
           key: linux-ppc64le-assets-{{ .Revision }}
           paths: ~/docker/linux-ppc64le.tar
@@ -517,27 +522,32 @@ workflows:
         - browser-asmjs:
             requires:
               - base
-        - linux-arm64:
-            requires:
-              - base
-        - linux-armv5:
-            requires:
-              - base
+        # Image build currently broken. See #209
+        #- linux-arm64:
+            #requires:
+              #- base
+        # Image build currently broken. See #209
+        #- linux-armv5:
+            #requires:
+              #- base
         - linux-armv6:
             requires:
               - base
-        - linux-armv7:
-            requires:
-              - base
-        - linux-mipsel:
-            requires:
-              - base
+        # Image build currently broken. See #209
+        #- linux-armv7:
+            #requires:
+              #- base
+        # Image build currently broken. See #209
+        #- linux-mipsel:
+            #requires:
+              #- base
         - linux-s390x:
             requires:
               - base
-        - linux-ppc64le:
-            requires:
-              - base
+        # Image build currently broken. See #209
+        #- linux-ppc64le:
+            #requires:
+              #- base
         - linux-x64:
             requires:
               - base
@@ -562,13 +572,16 @@ workflows:
               - android-arm
               - android-arm64
               - browser-asmjs
-              - linux-arm64
-              - linux-armv5
+              # Image build currently broken. See #209
+              #- linux-arm64
+              #- linux-armv5
               - linux-armv6
-              - linux-armv7
-              - linux-mipsel
+              # Image build currently broken. See #209
+              #- linux-armv7
+              #- linux-mipsel
               - linux-s390x
-              - linux-ppc64le
+              # Image build currently broken. See #209
+              #- linux-ppc64le
               - linux-x64
               - linux-x86
               - manylinux-x64


### PR DESCRIPTION
Temporarily disable because the packages are not available. See #209.

These should be replaced by crosstool-ng images.