### PR TITLE
Wsl better support

### DIFF
--- a/imagefiles/dockcross
+++ b/imagefiles/dockcross
@@ -183,18 +183,15 @@ fi
 
 # Change the PWD when working in Docker on Windows
 if [ -n "$UBUNTU_ON_WINDOWS" ]; then
-    WSL_ROOT = "/\/mnt\//"
-
+    WSL_ROOT="/mnt/"
     CFG_FILE=/etc/wsl.conf
     CFG_CONTENT=$(cat $CFG_FILE | sed -r '/[^=]+=[^=]+/!d' | sed -r 's/\s+=\s/=/g')
     eval "$CFG_CONTENT"
-    if [ -n "$root"]
+    if [ -n "$root" ]; then
         WSL_ROOT=$root
-
+    fi
     HOST_PWD=`pwd -P`
-    
     HOST_PWD=${HOST_PWD/$WSL_ROOT//}
-    HOST_PWD=${HOST_PWD/\//:\/}
 elif [ -n "$MSYS" ]; then
     HOST_PWD=$PWD
     HOST_PWD=${HOST_PWD/\//}

--- a/imagefiles/dockcross
+++ b/imagefiles/dockcross
@@ -183,8 +183,17 @@ fi
 
 # Change the PWD when working in Docker on Windows
 if [ -n "$UBUNTU_ON_WINDOWS" ]; then
+    WSL_ROOT = "/\/mnt\//"
+
+    CFG_FILE=/etc/wsl.conf
+    CFG_CONTENT=$(cat $CFG_FILE | sed -r '/[^=]+=[^=]+/!d' | sed -r 's/\s+=\s/=/g')
+    eval "$CFG_CONTENT"
+    if [ -n "$root"]
+        WSL_ROOT=$root
+
     HOST_PWD=`pwd -P`
-    HOST_PWD=${HOST_PWD/\/mnt\//}
+    
+    HOST_PWD=${HOST_PWD/$WSL_ROOT//}
     HOST_PWD=${HOST_PWD/\//:\/}
 elif [ -n "$MSYS" ]; then
     HOST_PWD=$PWD


### PR DESCRIPTION
From https://nickjanetakis.com/blog/setting-up-docker-for-windows-and-wsl-to-work-flawlessly#ensure-volume-mounts-work

>When using WSL, Docker for Windows expects you to supply your volume paths in a format that matches this: /c/Users/nick/dev/myapp.

>Create and modify the new WSL configuration file:
>sudo nano /etc/wsl.conf
>
>Now make it look like this and save the file when you're done:
>[automount]
>root = /
>options = "metadata"