### PR TITLE
Added new image windows-x64-posix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,6 +314,25 @@ jobs:
       - save_cache:
           key: windows-x64-assets-{{ .Revision }}
           paths: ~/docker/windows-x64.tar
+  windows-x64-posix:
+    <<: *build-settings
+    steps:
+      - restore_cache:
+          key: base-assets-{{ .Revision }}
+      - run:
+         no_output_timeout: 1.5h
+         name: windows-x64-posix build
+         command: |
+           docker load -i ~/docker/base.tar
+           make windows-x64-posix
+           docker save -o ~/docker/windows-x64-posix.tar dockcross/windows-x64-posix:latest
+      - run:
+         name: windows-x64-posix test
+         command: |
+           make windows-x64-posix.test
+      - save_cache:
+          key: windows-x64-posix-assets-{{ .Revision }}
+          paths: ~/docker/windows-x64-posix.tar
   windows-x86:
     <<: *build-settings
     steps:
@@ -501,6 +520,16 @@ jobs:
               docker push dockcross/windows-x64:latest
             fi
       - restore_cache:
+          key: windows-x64-posix-assets-{{ .Revision }}
+      - deploy:
+          name: Deploy windows-x64-posix
+          command: |
+            docker load -i ~/docker/windows-x64-posix.tar
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              docker login -u $DOCKER_USER -p $DOCKER_PASS
+              docker push dockcross/windows-x64-posix:latest
+            fi
+      - restore_cache:
           key: windows-x86-assets-{{ .Revision }}
       - deploy:
           name: Deploy windows-x86
@@ -565,6 +594,9 @@ workflows:
         - windows-x64:
             requires:
               - base
+        - windows-x64-posix:
+            requires:
+              - base
         - windows-x86:
             requires:
               - base
@@ -588,4 +620,5 @@ workflows:
               - manylinux-x64
               - manylinux-x86
               - windows-x64
+              - windows-x64-posix
               - windows-x86

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ ORG = dockcross
 BIN = ./bin
 
 # These images are built using the "build implicit rule"
-STANDARD_IMAGES = linux-s390x android-arm android-arm64 linux-x86 linux-x64 linux-arm64 linux-armv5 linux-armv6 linux-armv7 linux-mips linux-mipsel linux-ppc64le windows-x86 windows-x64
+STANDARD_IMAGES = linux-s390x android-arm android-arm64 linux-x86 linux-x64 linux-arm64 linux-armv5 linux-armv6 linux-armv7 linux-mips linux-mipsel linux-ppc64le windows-x86 windows-x64 windows-x64-posix
 
 # Generated Dockerfiles.
-GEN_IMAGES = linux-s390x linux-mips manylinux-x86 manylinux-x64 browser-asmjs linux-arm64 windows-x86 windows-x64
+GEN_IMAGES = linux-s390x linux-mips manylinux-x86 manylinux-x64 browser-asmjs linux-arm64 windows-x86 windows-x64 windows-x64-posix
 GEN_IMAGE_DOCKERFILES = $(addsuffix /Dockerfile,$(GEN_IMAGES))
 
 # These images are expected to have explicit rules for *both* build and testing
@@ -31,6 +31,7 @@ IMAGES = $(STANDARD_IMAGES) $(NON_STANDARD_IMAGES)
 linux-ppc64le.test_ARGS = --languages C
 windows-x86.test_ARGS = --exe-suffix ".exe"
 windows-x64.test_ARGS = --exe-suffix ".exe"
+windows-x64-posix.test_ARGS = --exe-suffix ".exe"
 
 # On CircleCI, do not attempt to delete container
 # See https://circleci.com/docs/docker-btrfs-error/

--- a/README.rst
+++ b/README.rst
@@ -201,14 +201,21 @@ dockcross/manylinux-x86
   :target: https://microbadger.com/images/dockcross/windows-x64
 
 dockcross/windows-x64
-  |windows-x64-images| 64-bit Windows cross-compiler based on MXE/MinGW-w64.
+  |windows-x64-images| 64-bit Windows cross-compiler based on MXE/MinGW-w64 with win32 threads.
+
+
+.. |windows-x64-posix-images| image:: https://images.microbadger.com/badges/image/dockcross/windows-x64-posix.svg
+  :target: https://microbadger.com/images/dockcross/windows-x64-posix
+
+dockcross/windows-x64-posix
+  |windows-x64-posix-images| 64-bit Windows cross-compiler based on MXE/MinGW-w64 with posix threads.
 
 
 .. |windows-x86-images| image:: https://images.microbadger.com/badges/image/dockcross/windows-x86.svg
   :target: https://microbadger.com/images/dockcross/windows-x86
 
 dockcross/windows-x86
-  |windows-x86-images| 32-bit Windows cross-compiler based on MXE/MinGW-w64.
+  |windows-x86-images| 32-bit Windows cross-compiler based on MXE/MinGW-w64 with win32 threads.
 
 
 Articles

--- a/common.windows
+++ b/common.windows
@@ -4,17 +4,19 @@
 #
 # WINEARCH environment variable to either "win64" or "win32"
 # MXE_TARGET_ARCH argument to either "x86_64" or "i686". See http://mxe.cc/
+# MXE_TARGET_THREAD argument to either "" or ".posix". Default is win32. See http://mxe.cc/
 #
 # For example:
 #
 #  ENV WINEARCH win64
 #  ARG MXE_TARGET_ARCH=x86_64
+#  ARG MXE_TARGET_THREAD=
 #
 
 # mxe master 2017-10-25
 ARG MXE_GIT_TAG=994ad47302e8811614b7eb49fc05234942b95b89
 
-ENV CMAKE_TOOLCHAIN_FILE /usr/src/mxe/usr/${MXE_TARGET_ARCH}-w64-mingw32.static/share/cmake/mxe-conf.cmake
+ENV CMAKE_TOOLCHAIN_FILE /usr/src/mxe/usr/${MXE_TARGET_ARCH}-w64-mingw32.static${MXE_TARGET_THREAD}/share/cmake/mxe-conf.cmake
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -81,10 +83,10 @@ RUN \
   # Configure "settings.mk" required to build MXE
   #
   cd /usr/src/mxe && \
-  echo "MXE_TARGETS := ${MXE_TARGET_ARCH}-w64-mingw32.static" > settings.mk && \
-  echo "LOCAL_PKG_LIST := gcc"                                >> settings.mk && \
-  echo ".DEFAULT local-pkg-list:"                             >> settings.mk && \
-  echo "local-pkg-list: \$(LOCAL_PKG_LIST)"                   >> settings.mk && \
+  echo "MXE_TARGETS := ${MXE_TARGET_ARCH}-w64-mingw32.static${MXE_TARGET_THREAD}" > settings.mk && \
+  echo "LOCAL_PKG_LIST := gcc"                                                   >> settings.mk && \
+  echo ".DEFAULT local-pkg-list:"                                                >> settings.mk && \
+  echo "local-pkg-list: \$(LOCAL_PKG_LIST)"                                      >> settings.mk && \
   #
   # Build MXE
   #
@@ -104,11 +106,11 @@ RUN \
   #
   cd /usr/bin && \
   rm cmake cpack && \
-  ln -s /usr/src/mxe/usr/bin/${MXE_TARGET_ARCH}-w64-mingw32.static-cmake cmake && \
-  ln -s /usr/src/mxe/usr/bin/${MXE_TARGET_ARCH}-w64-mingw32.static-cpack cpack
+  ln -s /usr/src/mxe/usr/bin/${MXE_TARGET_ARCH}-w64-mingw32.static${MXE_TARGET_THREAD}-cmake cmake && \
+  ln -s /usr/src/mxe/usr/bin/${MXE_TARGET_ARCH}-w64-mingw32.static${MXE_TARGET_THREAD}-cpack cpack
 
 ENV PATH ${PATH}:/usr/src/mxe/usr/bin
-ENV CROSS_TRIPLE ${MXE_TARGET_ARCH}-w64-mingw32.static
+ENV CROSS_TRIPLE ${MXE_TARGET_ARCH}-w64-mingw32.static${MXE_TARGET_THREAD}
 ENV AS=/usr/src/mxe/usr/bin/${CROSS_TRIPLE}-as \
     AR=/usr/src/mxe/usr/bin/${CROSS_TRIPLE}-ar \
     CC=/usr/src/mxe/usr/bin/${CROSS_TRIPLE}-gcc \

--- a/windows-x64-posix/Dockerfile.in
+++ b/windows-x64-posix/Dockerfile.in
@@ -1,0 +1,21 @@
+FROM dockcross/base:latest
+MAINTAINER Matt McCormick "matt.mccormick@kitware.com"
+
+ENV WINEARCH win64
+ARG MXE_TARGET_ARCH=x86_64
+ARG MXE_TARGET_THREAD=.posix
+
+#include "common.windows"
+
+ENV DEFAULT_DOCKCROSS_IMAGE dockcross/windows-x64-posix
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/windows-x64/Dockerfile.in
+++ b/windows-x64/Dockerfile.in
@@ -3,6 +3,7 @@ MAINTAINER Matt McCormick "matt.mccormick@kitware.com"
 
 ENV WINEARCH win64
 ARG MXE_TARGET_ARCH=x86_64
+ARG MXE_TARGET_THREAD=
 
 #include "common.windows"
 

--- a/windows-x86/Dockerfile.in
+++ b/windows-x86/Dockerfile.in
@@ -3,6 +3,7 @@ MAINTAINER Matt McCormick "matt.mccormick@kitware.com"
 
 ENV WINEARCH win32
 ARG MXE_TARGET_ARCH=i686
+ARG MXE_TARGET_THREAD=
 
 #include "common.windows"
 


### PR DESCRIPTION
This pull request adds new image windows-x64-posix.

This is based on @jcfr's recent windows refactoring.

To do so, I have added variable `MXE_TARGET_THREAD` that is empty for the classical windows image, and set to `.posix` for posix image. This variable is inserted to access the correct programs while building image and for variable `MXE_TARGETS` used by mxe.

It should address problem reported [here](https://github.com/dockcross/dockcross/issues/216) and discussed with @thewtex  and @jcfr.

I wanted to add a simple test program cpp with `std::thread` inside, but had no clue how to insert 
We could do the same for fortran programs.

Other things:

- it would be nice to link images found on [dockerhub](https://hub.docker.com/r/dockcross) and on GitHub: for example having git sha on dockcross
- maybe, some tags could be used?
