### PR TITLE
common: Fix bash shell script invocation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -302,7 +302,7 @@ Per-project dockcross configuration
 If a shell script named ``.dockcross`` is found in the current directory where
 the dockcross script is started, it is executed before the dockcross script
 ``command`` argument.  The shell script is expected to have a shebang like
-``#!/bin/bash``.
+``#!/usr/bin/env bash``.
 
 For example, commands like ``git config --global advice.detachedHead false`` can
 be added to this script.

--- a/imagefiles/build-and-install-cmake.sh
+++ b/imagefiles/build-and-install-cmake.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/imagefiles/build-and-install-curl.sh
+++ b/imagefiles/build-and-install-curl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/imagefiles/build-and-install-git.sh
+++ b/imagefiles/build-and-install-git.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/imagefiles/build-and-install-ninja.sh
+++ b/imagefiles/build-and-install-ninja.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Configure, build and install ninja

--- a/imagefiles/build-and-install-openssh.sh
+++ b/imagefiles/build-and-install-openssh.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/imagefiles/build-and-install-openssl.sh
+++ b/imagefiles/build-and-install-openssl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Configure, build and install OpenSSL
 #

--- a/imagefiles/ccmake.sh
+++ b/imagefiles/ccmake.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # Always pass the CMAKE_TOOLCHAIN_FILE variable to CMake when inside a
 # dockcross environment -- the CMAKE_TOOLCHAIN_FILE environmental variable is

--- a/imagefiles/cmake.sh
+++ b/imagefiles/cmake.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # Always pass the CMAKE_TOOLCHAIN_FILE variable to CMake when inside a
 # dockcross environment -- the CMAKE_TOOLCHAIN_FILE environmental variable is

--- a/imagefiles/dockcross
+++ b/imagefiles/dockcross
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DEFAULT_DOCKCROSS_IMAGE=dockcross/base  # DO NOT MOVE THIS LINE (see entrypoint.sh)
 

--- a/imagefiles/entrypoint.sh
+++ b/imagefiles/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This is the entrypoint script for the dockerfile. Executed in the
 # container at runtime.

--- a/imagefiles/install-cmake-binary.sh
+++ b/imagefiles/install-cmake-binary.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 set -o pipefail

--- a/imagefiles/install-crosstool-ng-toolchain.sh
+++ b/imagefiles/install-crosstool-ng-toolchain.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script operates in a current working directory. It downloads
 # "crosstool-ng", installs the base package, and then configures and installs

--- a/imagefiles/install-gosu-binary.sh
+++ b/imagefiles/install-gosu-binary.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 set -o pipefail

--- a/imagefiles/install-liquidprompt-binary.sh
+++ b/imagefiles/install-liquidprompt-binary.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/imagefiles/install-python-packages.sh
+++ b/imagefiles/install-python-packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -o pipefail

--- a/imagefiles/utils.sh
+++ b/imagefiles/utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/linux-x86/i686-linux-gnu-as.sh
+++ b/linux-x86/i686-linux-gnu-as.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 exec ${0/${CROSS_TRIPLE}-/x86_64-linux-gnu-} --32 "$@"

--- a/linux-x86/i686-linux-gnu.sh
+++ b/linux-x86/i686-linux-gnu.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 exec ${0/*${TOOLCHAIN}-/\/usr\/bin\/x86_64-linux-gnu-} -m32 "$@"

--- a/manylinux-common/install-python-packages.sh
+++ b/manylinux-common/install-python-packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 for PIP in /opt/python/*/bin/pip; do
   $PIP install --disable-pip-version-check --upgrade pip

--- a/manylinux-common/pre_exec.sh
+++ b/manylinux-common/pre_exec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 for DIR in /opt/python/*/lib/python*/site-packages; do
   chown -R $BUILDER_UID:$BUILDER_GID $DIR


### PR DESCRIPTION
`#!/usr/bin/env bash` should be used to avoid hard paths.

To address:

  dockcross-manylinux-x64: bad interpreter: /bin/bash^M: no such file or directory