### PR TITLE
manylinux: Re-build images using latest base images

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -185,7 +185,7 @@ dockcross/linux-x86
   :target: https://microbadger.com/images/dockcross/manylinux-x64
 
 dockcross/manylinux-x64
-  |manylinux-x64-images| Docker `manylinux <https://github.com/pypa/manylinux>`_ image for building Linux x86_64 / amd64 `Python wheel packages <http://pythonwheels.com/>`_.
+  |manylinux-x64-images| Docker `manylinux <https://github.com/pypa/manylinux>`_ image for building Linux x86_64 / amd64 `Python wheel packages <http://pythonwheels.com/>`_. It includes Python 2.7, 3.4, 3.5, 3.6 and 3.7.
   Also has support for the dockcross script, and it has installations of CMake, Ninja, and `scikit-build <http://scikit-build.org>`_
 
 
@@ -193,7 +193,7 @@ dockcross/manylinux-x64
   :target: https://microbadger.com/images/dockcross/manylinux-x86
 
 dockcross/manylinux-x86
-  |manylinux-x86-images| Docker `manylinux <https://github.com/pypa/manylinux>`_ image for building Linux i686 `Python wheel packages <http://pythonwheels.com/>`_.
+  |manylinux-x86-images| Docker `manylinux <https://github.com/pypa/manylinux>`_ image for building Linux i686 `Python wheel packages <http://pythonwheels.com/>`_. It includes Python 2.7, 3.4, 3.5, 3.6 and 3.7.
   Also has support for the dockcross script, and it has installations of CMake, Ninja, and `scikit-build <http://scikit-build.org>`_
 
 

--- a/android-arm64/Dockerfile
+++ b/android-arm64/Dockerfile
@@ -1,6 +1,9 @@
 FROM dockcross/base:latest
 MAINTAINER Matt McCormick "matt.mccormick@kitware.com"
-RUN dpkg --add-architecture arm64 ; apt-get update
+RUN \
+  sed -i '/debian-security/d' /etc/apt/sources.list && \
+  dpkg --add-architecture arm64 && \
+  apt-get update
 
 # The cross-compiling emulator
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
The purpose of this commit is to rebuild the dockcross images against
the latest manylinux images including Python 3.7 and also updated
setuptools, autitwheel, git, curl, ...

Note that python 3.3 was removed from the image.

```
$ docker run -ti --rm quay.io/pypa/manylinux1_x86_64 bash -c "ls -1 /opt/python/"
cp27-cp27m
cp27-cp27mu
cp34-cp34m
cp35-cp35m
cp36-cp36m
cp37-cp37m
```