### PR TITLE
do not delete mxe's .git directory

### DIFF
--- a/common.windows
+++ b/common.windows
@@ -96,7 +96,7 @@ RUN \
   # Cleanup: By keeping the MXE build system (Makefile, ...), derived images will be able to install
   #          additional packages.
   #
-  rm -rf .git log pkg && \
+  rm -rf log pkg && \
   #
   # Update MXE toolchain file
   #


### PR DESCRIPTION
Contrary to the comment above this line, deleting the .git directory breaks build of additional packages in derived images.

Example of building bzip2 with the original Dockerfile:
```
fatal: Not a git repository (or any of the parent directories): .git
[pkg-list]  bzip2

-- snip -- (Downloading stuff)

Failed to build package bzip2 for target x86_64-w64-mingw32.static!
------------------------------------------------------------
Linux cd0675946b5d 4.4.0-130-generic #156-Ubuntu SMP Thu Jun 14 08:53:28 UTC 2018 x86_64 GNU/Linux
git log --pretty=tformat:"%H - %s [%ar] [%d]" -1
fatal: Not a git repository (or any of the parent directories): .git
Makefile:660: recipe for target 'build-only-bzip2_x86_64-w64-mingw32.static' failed
make[1]: *** [build-only-bzip2_x86_64-w64-mingw32.static] Error 128
make[1]: Leaving directory '/usr/src/mxe'
real	0m2.715s
user	0m2.596s
sys	0m0.064s
------------------------------------------------------------
[log]      /usr/src/mxe/log/bzip2_x86_64-w64-mingw32.static

Makefile:660: recipe for target '/usr/src/mxe/usr/x86_64-w64-mingw32.static/installed/bzip2' failed
make: *** [/usr/src/mxe/usr/x86_64-w64-mingw32.static/installed/bzip2] Error 1
```
with the .git directory still in place:
```
[pkg-list]  bzip2

-- snip -- (Downloading stuff)

[build]     bzip2                  x86_64-w64-mingw32.static
[done]      bzip2                  x86_64-w64-mingw32.static                              3180 KiB       0m3.565s
```