### PR TITLE
Pinned armv7 ABI to use hard float

### DIFF
--- a/linux-armv7/crosstool-ng.config
+++ b/linux-armv7/crosstool-ng.config
@@ -161,7 +161,7 @@ CT_ARCH_CPU="cortex-a7"
 CT_ARCH_TUNE=""
 CT_TARGET_CFLAGS=""
 CT_TARGET_LDFLAGS=""
-CT_ARCH_FLOAT=""
+CT_ARCH_FLOAT="hard"
 
 #
 # arm other options


### PR DESCRIPTION
This fixes the cross compiled runtime on a RPi.