### PR TITLE
Fix dockcross script for users/groups containing spaces

### DIFF
--- a/imagefiles/dockcross
+++ b/imagefiles/dockcross
@@ -178,7 +178,7 @@ UBUNTU_ON_WINDOWS=$([ -e /proc/version ] && grep -l Microsoft /proc/version || e
 MSYS=$([ -e /proc/version ] && grep -l MINGW /proc/version || echo "")
 
 if [ -z "$UBUNTU_ON_WINDOWS" -a -z "$MSYS" ]; then
-    USER_IDS="-e BUILDER_UID=$( id -u ) -e BUILDER_GID=$( id -g ) -e BUILDER_USER=$( id -un ) -e BUILDER_GROUP=$( id -gn )"
+    USER_IDS=(-e BUILDER_UID="$( id -u )" -e BUILDER_GID="$( id -g )" -e BUILDER_USER="$( id -un )" -e BUILDER_GROUP="$( id -gn )")
 fi
 
 # Change the PWD when working in Docker on Windows
@@ -220,7 +220,7 @@ CONTAINER_NAME=dockcross_$RANDOM
 docker run $TTY_ARGS --name $CONTAINER_NAME \
     -v "$HOST_PWD":/work \
     $HOST_VOLUMES \
-    $USER_IDS \
+    "${USER_IDS[@]}" \
     $FINAL_ARGS \
     $FINAL_IMAGE "$@"
 run_exit_code=$?


### PR DESCRIPTION
If `id -un` or `id -gn` outputs a name containing a space, e.g. when joined to an AD domain with SSSD, the current `dockcross` script would break and abort with an error: `docker: invalid reference format.`, because it would interpret the part after the space as an image name.