### PR TITLE
web-wasm: Rename image from browser-asmjs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,26 +64,26 @@ jobs:
       - save_cache:
           key: android-arm64-assets-{{ .Revision }}
           paths: ~/docker/android-arm64.tar
-  browser-asmjs:
+  web-wasm:
     <<: *build-settings
     steps:
       - restore_cache:
           key: base-assets-{{ .Revision }}
       - run:
-         name: browser-asmjs build
+         name: web-wasm build
          no_output_timeout: 1.5h
          command: |
            docker load -i ~/docker/base.tar
-           make browser-asmjs
-           tagged=$(docker images -q -f 'since=dockcross/browser-asmjs:latest' --format '{{.Repository}}:{{.Tag}}' | grep browser-asmjs)
-           docker save -o ~/docker/browser-asmjs.tar dockcross/browser-asmjs:latest $tagged
+           make web-wasm
+           tagged=$(docker images -q -f 'since=dockcross/web-wasm:latest' --format '{{.Repository}}:{{.Tag}}' | grep web-wasm)
+           docker save -o ~/docker/web-wasm.tar dockcross/web-wasm:latest $tagged
       - run:
-         name: browser-asmjs test
+         name: web-wasm test
          command: |
-           make browser-asmjs.test
+           make web-wasm.test
       - save_cache:
-          key: browser-asmjs-assets-{{ .Revision }}
-          paths: ~/docker/browser-asmjs.tar
+          key: web-wasm-assets-{{ .Revision }}
+          paths: ~/docker/web-wasm.tar
   linux-arm64:
     <<: *build-settings
     steps:
@@ -404,15 +404,15 @@ jobs:
               docker push $tagged
             fi
       - restore_cache:
-          key: browser-asmjs-assets-{{ .Revision }}
+          key: web-wasm-assets-{{ .Revision }}
       - deploy:
-          name: Deploy browser-asmjs
+          name: Deploy web-wasm
           command: |
-            docker load -i ~/docker/browser-asmjs.tar
+            docker load -i ~/docker/web-wasm.tar
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
               docker login -u $DOCKER_USER -p $DOCKER_PASS
-              docker push dockcross/browser-asmjs:latest
-              tagged=$(docker images -q -f 'since=dockcross/browser-asmjs:latest' --format '{{.Repository}}:{{.Tag}}' | grep browser-asmjs)
+              docker push dockcross/web-wasm:latest
+              tagged=$(docker images -q -f 'since=dockcross/web-wasm:latest' --format '{{.Repository}}:{{.Tag}}' | grep web-wasm)
               docker push $tagged
             fi
       - restore_cache:
@@ -597,7 +597,7 @@ workflows:
         - android-arm64:
             requires:
               - base
-        - browser-asmjs:
+        - web-wasm:
             requires:
               - base
         - linux-arm64:
@@ -649,7 +649,7 @@ workflows:
               - base
               - android-arm
               - android-arm64
-              - browser-asmjs
+              - web-wasm
               - linux-arm64
               - linux-armv5
               - linux-armv6

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@ bin
 dockcross
 */test/
 Dockerfile
-browser-asmjs/Dockerfile
+web-wasm/Dockerfile
 */imagefiles/*
 !imagefiles/*

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@ BIN = ./bin
 STANDARD_IMAGES = linux-s390x android-arm android-arm64 linux-x86 linux-x64 linux-arm64 linux-armv5 linux-armv6 linux-armv7 linux-mips linux-mipsel linux-ppc64le windows-x86 windows-x64 windows-x64-posix
 
 # Generated Dockerfiles.
-GEN_IMAGES = linux-s390x linux-mips manylinux-x86 manylinux-x64 browser-asmjs linux-arm64 windows-x86 windows-x64 windows-x64-posix linux-armv7 linux-armv5
+GEN_IMAGES = linux-s390x linux-mips manylinux-x86 manylinux-x64 web-wasm linux-arm64 windows-x86 windows-x64 windows-x64-posix linux-armv7 linux-armv5
 GEN_IMAGE_DOCKERFILES = $(addsuffix /Dockerfile,$(GEN_IMAGES))
 
 # These images are expected to have explicit rules for *both* build and testing
-NON_STANDARD_IMAGES = browser-asmjs manylinux-x64 manylinux-x86
+NON_STANDARD_IMAGES = web-wasm manylinux-x64 manylinux-x86
 
 DOCKER_COMPOSITE_SOURCES = common.docker common.debian common.manylinux common.crosstool common.windows
 
@@ -67,32 +67,32 @@ $(GEN_IMAGE_DOCKERFILES) Dockerfile: %Dockerfile: %Dockerfile.in $(DOCKER_COMPOS
 		$< > $@
 
 #
-# browser-asmjs
+# web-wasm
 #
-browser-asmjs: browser-asmjs/Dockerfile
+web-wasm: web-wasm/Dockerfile
 	mkdir -p $@/imagefiles && cp -r imagefiles $@/
-	cp -r test browser-asmjs/
-	$(DOCKER) build -t $(ORG)/browser-asmjs:latest \
-		--build-arg IMAGE=$(ORG)/browser-asmjs \
+	cp -r test web-wasm/
+	$(DOCKER) build -t $(ORG)/web-wasm:latest \
+		--build-arg IMAGE=$(ORG)/web-wasm \
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \
 		--build-arg VCS_URL=`git config --get remote.origin.url` \
 		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
-		browser-asmjs
-	$(DOCKER) build -t $(ORG)/browser-asmjs:$(TAG) \
-		--build-arg IMAGE=$(ORG)/browser-asmjs \
+		web-wasm
+	$(DOCKER) build -t $(ORG)/web-wasm:$(TAG) \
+		--build-arg IMAGE=$(ORG)/web-wasm \
 		--build-arg VERSION=$(TAG) \
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \
 		--build-arg VCS_URL=`git config --get remote.origin.url` \
 		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
-		browser-asmjs
-	rm -rf browser-asmjs/test
+		web-wasm
+	rm -rf web-wasm/test
 	rm -rf $@/imagefiles
 
-browser-asmjs.test: browser-asmjs
-	cp -r test browser-asmjs/
-	$(DOCKER) run $(RM) dockcross/browser-asmjs > $(BIN)/dockcross-browser-asmjs && chmod +x $(BIN)/dockcross-browser-asmjs
-	$(BIN)/dockcross-browser-asmjs python test/run.py --exe-suffix ".js"
-	rm -rf browser-asmjs/test
+web-wasm.test: web-wasm
+	cp -r test web-wasm/
+	$(DOCKER) run $(RM) dockcross/web-wasm > $(BIN)/dockcross-web-wasm && chmod +x $(BIN)/dockcross-web-wasm
+	$(BIN)/dockcross-web-wasm python test/run.py --exe-suffix ".js"
+	rm -rf web-wasm/test
 
 #
 # manylinux-x64

--- a/README.rst
+++ b/README.rst
@@ -103,11 +103,11 @@ dockcross/android-arm64
   |android-arm64-images| The Android NDK standalone toolchain for the arm64
   architecture.
 
-.. |browser-asmjs-images| image:: https://images.microbadger.com/badges/image/dockcross/browser-asmjs.svg
-  :target: https://microbadger.com/images/dockcross/browser-asmjs
+.. |web-wasm-images| image:: https://images.microbadger.com/badges/image/dockcross/web-wasm.svg
+  :target: https://microbadger.com/images/dockcross/web-wasm
 
-dockcross/browser-asmjs
-  |browser-asmjs-images| The Emscripten JavaScript cross compiler.
+dockcross/web-wasm
+  |web-wasm-images| The Emscripten WebAssembly/asm.js/JavaScript cross compiler.
 
 
 .. |linux-arm64-images| image:: https://images.microbadger.com/badges/image/dockcross/linux-arm64.svg

--- a/web-wasm/Dockerfile.in
+++ b/web-wasm/Dockerfile.in
@@ -21,7 +21,7 @@ ENV CMAKE_TOOLCHAIN_FILE /emsdk_portable/sdk/cmake/Modules/Platform/Emscripten.c
 
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
-ARG IMAGE=dockcross/browser-asmjs
+ARG IMAGE=dockcross/web-wasm
 ARG VERSION=latest
 ARG VCS_REF
 ARG VCS_URL


### PR DESCRIPTION
WebAssembly has a better mindshare than asm.js. In the future, it will
be used in much more than browsers. Also, newer versions of Emscripten
default to WebAssembly.