### PR TITLE
Added libtool and automake to the linux-armv7a target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,10 @@ jobs:
       - run:
          name: base build
          command: |
-           docker pull debian:jessie
+           docker pull debian:stretch-slim
            make base
            mkdir -p ~/docker
-           docker save -o ~/docker/base.tar debian:jessie dockcross/base:latest
+           docker save -o ~/docker/base.tar debian:stretch-slim dockcross/base:latest
       - run:
          name: base test
          command: |

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM debian:jessie-20181112
+FROM debian:stretch-20190326-slim
 MAINTAINER Matt McCormick "matt.mccormick@kitware.com"
 
 #include "common.debian"

--- a/common.debian
+++ b/common.debian
@@ -5,10 +5,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG REPO=http://cdn-fastly.deb.debian.org
 
 RUN \
-  bash -c "echo \"deb $REPO/debian jessie main contrib non-free\" > /etc/apt/sources.list"  && \
-  bash -c "echo \"deb $REPO/debian jessie-updates main contrib non-free\" >> /etc/apt/sources.list"  && \
-  bash -c "echo \"deb $REPO/debian-security jessie/updates main\" >> /etc/apt/sources.list" && \
-  bash -c "echo \"deb http://ftp.debian.org/debian jessie-backports main\" >> /etc/apt/sources.list" && \
+  bash -c "echo \"deb $REPO/debian stretch main contrib non-free\" > /etc/apt/sources.list"  && \
+  bash -c "echo \"deb $REPO/debian stretch-updates main contrib non-free\" >> /etc/apt/sources.list"  && \
+  bash -c "echo \"deb $REPO/debian-security stretch/updates main\" >> /etc/apt/sources.list" && \
+  bash -c "echo \"deb http://ftp.debian.org/debian stretch-backports main\" >> /etc/apt/sources.list" && \
   apt-get update --yes && \
   apt-get install --no-install-recommends --yes \
     automake \
@@ -19,9 +19,11 @@ RUN \
     bzip2 \
     ca-certificates \
     curl \
+    dirmngr \
     file \
     gettext \
     gzip \
+    gnupg \
     zip \
     make \
     ncurses-dev \

--- a/imagefiles/install-gosu-binary.sh
+++ b/imagefiles/install-gosu-binary.sh
@@ -33,7 +33,14 @@ curl -o /usr/local/bin/gosu.asc -# -SL $url_key
 
 gpg --verify /usr/local/bin/gosu.asc
 
-# cleanup
+# cleanup -- need to kill agent so that there is no race condition for
+# agent files in $GNUPGHOME.  Only need to do this on newer distros
+# with gpgconf installed
+GPGCONF_BIN="$(command -v gpgconf)" || true
+if [ -n "$GPGCONF_BIN" ] && [ -x $GPGCONF_BIN ]; then
+	gpgconf --kill gpg-agent 
+fi
+
 rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc
 
 chmod +x /usr/local/bin/gosu

--- a/linux-armv7a/crosstool-ng.config
+++ b/linux-armv7a/crosstool-ng.config
@@ -599,3 +599,4 @@ CT_LIBTOOL_VERSION="2.4.6"
 # Test suite
 #
 # CT_TEST_SUITE_GCC is not set
+

--- a/linux-armv7a/crosstool-ng.config
+++ b/linux-armv7a/crosstool-ng.config
@@ -586,8 +586,12 @@ CT_NCURSES_TARGET_FALLBACKS=""
 #
 # CT_COMP_TOOLS_FOR_HOST is not set
 # CT_COMP_TOOLS_autoconf is not set
-# CT_COMP_TOOLS_automake is not set
-# CT_COMP_TOOLS_libtool is not set
+CT_COMP_TOOLS_automake=y
+CT_AUTOMAKE_V_1_15=y
+CT_AUTOMAKE_VERSION="1.15"
+CT_COMP_TOOLS_libtool=y
+CT_LIBTOOL_V_2_4_6=y
+CT_LIBTOOL_VERSION="2.4.6"
 # CT_COMP_TOOLS_m4 is not set
 # CT_COMP_TOOLS_make is not set
 

--- a/linux-ppc64le/Dockerfile
+++ b/linux-ppc64le/Dockerfile
@@ -37,9 +37,6 @@ ENV AS=/usr/bin/${CROSS_TRIPLE}-as \
 
 WORKDIR /work
 
-# Note: Toolchain file support is currently in debian Experimental according to:
-# https://wiki.debian.org/CrossToolchains#In_jessie_.28Debian_8.29
-# We can switch to that when it becomes stable.
 COPY Toolchain.cmake /usr/lib/${CROSS_TRIPLE}/
 ENV CMAKE_TOOLCHAIN_FILE /usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
 

--- a/linux-x86/Dockerfile
+++ b/linux-x86/Dockerfile
@@ -33,8 +33,6 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
     CXX=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-g++
 
-# Note: Toolchain file support is currently in debian Experimental:
-# https://wiki.debian.org/CrossToolchains#In_jessie_.28Debian_8.29
 COPY Toolchain.cmake /usr/lib/${CROSS_TRIPLE}/
 ENV CMAKE_TOOLCHAIN_FILE /usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
 


### PR DESCRIPTION
The linux-armv7a target did not have libtool and automake enabled in its image.  These tools are used in many linux projects and are enabled in the other linux-arm* images.  This patch simply enables them for linux-armv7a as well.

Tested by generating a new linux-armv7a image and built a project that requires libtool (libfuse).  Also confirmed automake was available as version 1.15
