### PR TITLE
updated debian sources list to remove old jessie sources

### DIFF
--- a/common.debian
+++ b/common.debian
@@ -6,9 +6,7 @@ ARG REPO=http://cdn-fastly.deb.debian.org
 
 RUN \
   bash -c "echo \"deb $REPO/debian jessie main contrib non-free\" > /etc/apt/sources.list"  && \
-  bash -c "echo \"deb $REPO/debian jessie-updates main contrib non-free\" >> /etc/apt/sources.list"  && \
   bash -c "echo \"deb $REPO/debian-security jessie/updates main\" >> /etc/apt/sources.list" && \
-  bash -c "echo \"deb http://ftp.debian.org/debian jessie-backports main\" >> /etc/apt/sources.list" && \
   apt-get update --yes && \
   apt-get install --no-install-recommends --yes \
     automake \


### PR DESCRIPTION
Jessie has recently entered old stable mode.  This means the backports and jessie-updates sources have become unmaintained.  This pull request simply removes these sources as they are no longer available and break the build.  

dockcross should likely be updated to the latest stable debian release, but I understand there is move work to be done to make this happen (#209).  So in the mean time this update should fix the build.