### PR TITLE
updated armv7a to enable libtool and automake

### DIFF
--- a/linux-armv7a/crosstool-ng.config
+++ b/linux-armv7a/crosstool-ng.config
@@ -588,6 +588,12 @@ CT_NCURSES_TARGET_FALLBACKS=""
 # CT_COMP_TOOLS_autoconf is not set
 # CT_COMP_TOOLS_automake is not set
 # CT_COMP_TOOLS_libtool is not set
+CT_COMP_TOOLS_automake=y
+CT_AUTOMAKE_V_1_15=y
+CT_AUTOMAKE_VERSION="1.15"
+CT_COMP_TOOLS_libtool=y
+CT_LIBTOOL_V_2_4_6=y
+CT_LIBTOOL_VERSION="2.4.6"
 # CT_COMP_TOOLS_m4 is not set
 # CT_COMP_TOOLS_make is not set
 


### PR DESCRIPTION
automake and libtool are missing from the armv7a target (they are enabled in other targets).  This pull request adds them. 