### PR TITLE
Manylinux toolchains: restore CMAKE_CROSSCOMPILING

### DIFF
--- a/manylinux1-x64/Toolchain.cmake
+++ b/manylinux1-x64/Toolchain.cmake
@@ -1,14 +1,11 @@
 set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_CROSSCOMPILING FALSE)
 set(CMAKE_SYSTEM_VERSION 1)
 set(CMAKE_SYSTEM_PROCESSOR x86_64)
 
 set(MANYLINUX1 TRUE)
 
-set(cross_triple "x86_64-linux-gnu")
-
 set(CMAKE_C_COMPILER /opt/rh/devtoolset-2/root/usr/bin/gcc)
 set(CMAKE_CXX_COMPILER /opt/rh/devtoolset-2/root/usr/bin/g++)
 set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
 set(CMAKE_Fortran_COMPILER /opt/rh/devtoolset-2/root/usr/bin/gfortran)
-
-set(CMAKE_CROSSCOMPILING_EMULATOR /usr/bin/${cross_triple}-noop)

--- a/manylinux1-x86/Toolchain.cmake
+++ b/manylinux1-x86/Toolchain.cmake
@@ -1,10 +1,9 @@
 set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_CROSSCOMPILING FALSE)
 set(CMAKE_SYSTEM_VERSION 1)
 set(CMAKE_SYSTEM_PROCESSOR i686)
 
 set(MANYLINUX1 TRUE)
-
-set(cross_triple "i686-linux-gnu")
 
 set(CMAKE_C_COMPILER /opt/rh/devtoolset-2/root/usr/bin/gcc)
 set(CMAKE_CXX_COMPILER /opt/rh/devtoolset-2/root/usr/bin/g++)
@@ -14,5 +13,3 @@ set(CMAKE_Fortran_COMPILER /opt/rh/devtoolset-2/root/usr/bin/gfortran)
 # Discard path returned by pkg-config and associated with HINTS in module
 # like FindOpenSSL.
 set(CMAKE_IGNORE_PATH /usr/lib/x86_64-linux-gnu/ /usr/lib/x86_64-linux-gnu/lib/)
-
-set(CMAKE_CROSSCOMPILING_EMULATOR /usr/bin/${cross_triple}-noop)

--- a/manylinux2010-x64/Toolchain.cmake
+++ b/manylinux2010-x64/Toolchain.cmake
@@ -1,14 +1,11 @@
 set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_CROSSCOMPILING FALSE)
 set(CMAKE_SYSTEM_VERSION 1)
 set(CMAKE_SYSTEM_PROCESSOR x86_64)
 
 set(MANYLINUX2010 TRUE)
 
-set(cross_triple "x86_64-linux-gnu")
-
 set(CMAKE_C_COMPILER /opt/rh/devtoolset-8/root/usr/bin/gcc)
 set(CMAKE_CXX_COMPILER /opt/rh/devtoolset-8/root/usr/bin/g++)
 set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
 set(CMAKE_Fortran_COMPILER /opt/rh/devtoolset-8/root/usr/bin/gfortran)
-
-set(CMAKE_CROSSCOMPILING_EMULATOR /usr/bin/${cross_triple}-noop)


### PR DESCRIPTION
I tried it in a small cmake project: as described in #326, setting `CMAKE_SYSTEM_NAME` will have cmake set `CMAKE_CROSSCOMPILING` to `TRUE`. Which I believe is wrong in the manylinux case. Adding `set(CMAKE_CROSSCOMPILING FALSE)` to the `CMAKE_TOOLCHAIN_FILE` overrides that behavior.

I was not sure exactly how to check that it doesn't break anything in dockcross/manylinux*, so I figured I would open a PR to get feedback.

Resolves #326.