### PR TITLE
Manylinux toolchain: set MANYLINUX1/MANYLINUX2010 to TRUE

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -187,7 +187,7 @@ dockcross/linux-x86
 
 dockcross/manylinux2010-x64
   |manylinux2010-x64-images| Docker `manylinux2010 <https://github.com/pypa/manylinux>`_ image for building Linux x86_64 / amd64 `Python wheel packages <http://pythonwheels.com/>`_. It includes Python 2.7, 3.4, 3.5, 3.6, 3.7 and 3.8.
-  Also has support for the dockcross script, and it has installations of CMake, Ninja, and `scikit-build <http://scikit-build.org>`_
+  Also has support for the dockcross script, and it has installations of CMake, Ninja, and `scikit-build <http://scikit-build.org>`_. For CMake, it sets `MANYLINUX2010` to "TRUE" in the toolchain.
 
 
 .. |manylinux1-x64-images| image:: https://images.microbadger.com/badges/image/dockcross/manylinux1-x64.svg
@@ -195,7 +195,7 @@ dockcross/manylinux2010-x64
 
 dockcross/manylinux1-x64
   |manylinux1-x64-images| Docker `manylinux1 <https://github.com/pypa/manylinux/tree/manylinux1>`_ image for building Linux x86_64 / amd64 `Python wheel packages <http://pythonwheels.com/>`_. It includes Python 2.7, 3.4, 3.5, 3.6, 3.7 and 3.8.
-  Also has support for the dockcross script, and it has installations of CMake, Ninja, and `scikit-build <http://scikit-build.org>`_
+  Also has support for the dockcross script, and it has installations of CMake, Ninja, and `scikit-build <http://scikit-build.org>`_. For CMake, it sets `MANYLINUX1` to "TRUE" in the toolchain.
 
 
 .. |manylinux1-x86-images| image:: https://images.microbadger.com/badges/image/dockcross/manylinux1-x86.svg
@@ -203,7 +203,7 @@ dockcross/manylinux1-x64
 
 dockcross/manylinux1-x86
   |manylinux1-x86-images| Docker `manylinux1 <https://github.com/pypa/manylinux/tree/manylinux1>`_ image for building Linux i686 `Python wheel packages <http://pythonwheels.com/>`_. It includes Python 2.7, 3.4, 3.5, 3.6, 3.7 and 3.8.
-  Also has support for the dockcross script, and it has installations of CMake, Ninja, and `scikit-build <http://scikit-build.org>`_
+  Also has support for the dockcross script, and it has installations of CMake, Ninja, and `scikit-build <http://scikit-build.org>`_. For CMake, it sets `MANYLINUX1` to "TRUE" in the toolchain.
 
 
 .. |web-wasm-images| image:: https://images.microbadger.com/badges/image/dockcross/web-wasm.svg

--- a/manylinux1-x64/Toolchain.cmake
+++ b/manylinux1-x64/Toolchain.cmake
@@ -2,6 +2,8 @@ set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_VERSION 1)
 set(CMAKE_SYSTEM_PROCESSOR x86_64)
 
+set(MANYLINUX1 TRUE)
+
 set(cross_triple "x86_64-linux-gnu")
 
 set(CMAKE_C_COMPILER /opt/rh/devtoolset-2/root/usr/bin/gcc)

--- a/manylinux1-x86/Toolchain.cmake
+++ b/manylinux1-x86/Toolchain.cmake
@@ -2,6 +2,8 @@ set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_VERSION 1)
 set(CMAKE_SYSTEM_PROCESSOR i686)
 
+set(MANYLINUX1 TRUE)
+
 set(cross_triple "i686-linux-gnu")
 
 set(CMAKE_C_COMPILER /opt/rh/devtoolset-2/root/usr/bin/gcc)

--- a/manylinux2010-x64/Toolchain.cmake
+++ b/manylinux2010-x64/Toolchain.cmake
@@ -2,6 +2,8 @@ set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_VERSION 1)
 set(CMAKE_SYSTEM_PROCESSOR x86_64)
 
+set(MANYLINUX2010 TRUE)
+
 set(cross_triple "x86_64-linux-gnu")
 
 set(CMAKE_C_COMPILER /opt/rh/devtoolset-8/root/usr/bin/gcc)


### PR DESCRIPTION
So that one can do `if (MANYLINUX1)` in CMake, just like it is commonly done with e.g. `if (IOS)` or `if (MSVC)`.

I believe that it doesn't hurt, and it may be the only way to detect that it is a manylinux build (some projects already pass that information as an argument to the cmake call, which doesn't seem elegant to me).

Resolves #327.