### PR TITLE
Update Toolchain.cmake to use BOTH for CMAKE_FIND_ROOT_PATH_MODES

### DIFF
--- a/linux-armv7/Toolchain.cmake
+++ b/linux-armv7/Toolchain.cmake
@@ -12,8 +12,8 @@ set(CMAKE_CXX_FLAGS "-I ${cross_root}/include/")
 
 set(CMAKE_FIND_ROOT_PATH ${cross_root} ${cross_root}/${cross_triple})
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
-set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
-set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)
 set(CMAKE_SYSROOT ${cross_root}/${cross_triple}/sysroot)
 
 set(CMAKE_CROSSCOMPILING_EMULATOR /usr/bin/qemu-arm)


### PR DESCRIPTION
This is necessary if one wants to be able to use libraries or
includes or programs installed locally (and not on the system
of the build machine, or in CMAKE_SYSROOT, or in CMAKE_FIND_ROOT_PATH).

According to cmake order for find_* functions, CMAKE_FIND_ROOT_PATH
will be searched before the system of the build machine anyway,
which doesn't dramatically change the current behavior.

NOTE: This PR is only for linux-armv7 because that is the one I tested, but I believe I will have exactly the same issue on others. My idea was to open new PRs as I test those other systems.

Resolves #334.