### PR TITLE
Set environment variables for Linux kernel cross compilation

### DIFF
--- a/linux-arm64/Dockerfile.in
+++ b/linux-arm64/Dockerfile.in
@@ -31,6 +31,11 @@ ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
 
 ENV PKG_CONFIG_PATH /usr/lib/aarch64-linux-gnu/pkgconfig
 
+# Linux kernel cross compilation variables
+ENV PATH ${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE ${CROSS_TRIPLE}-
+ENV ARCH arm64
+
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
 ARG IMAGE=dockcross/linux-arm64

--- a/linux-armv5-musl/Dockerfile.in
+++ b/linux-armv5-musl/Dockerfile.in
@@ -33,6 +33,11 @@ ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
 
 ENV PKG_CONFIG_PATH /usr/lib/arm-linux-musleabihf/
 
+# Linux kernel cross compilation variables
+ENV PATH ${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE ${CROSS_TRIPLE}-
+ENV ARCH arm
+
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
 ARG IMAGE=dockcross/linux-armv5-musl

--- a/linux-armv5/Dockerfile.in
+++ b/linux-armv5/Dockerfile.in
@@ -35,6 +35,11 @@ ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
 
 ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabihf/
 
+# Linux kernel cross compilation variables
+ENV PATH ${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE ${CROSS_TRIPLE}-
+ENV ARCH arm
+
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
 ARG IMAGE=dockcross/linux-armv5

--- a/linux-armv6/Dockerfile
+++ b/linux-armv6/Dockerfile
@@ -43,6 +43,11 @@ ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${CROSS_ROOT}/libc/lib/${CRO
 COPY Toolchain.cmake ${CROSS_ROOT}/
 ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
 
+# Linux kernel cross compilation variables
+ENV PATH ${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE ${CROSS_TRIPLE}-
+ENV ARCH arm
+
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
 ARG IMAGE=dockcross/linux-armv6

--- a/linux-armv7/Dockerfile.in
+++ b/linux-armv7/Dockerfile.in
@@ -31,6 +31,11 @@ ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
 
 ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabihf/
 
+# Linux kernel cross compilation variables
+ENV PATH ${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE ${CROSS_TRIPLE}-
+ENV ARCH arm
+
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
 ARG IMAGE=dockcross/linux-armv7

--- a/linux-armv7a/Dockerfile.in
+++ b/linux-armv7a/Dockerfile.in
@@ -34,6 +34,11 @@ ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
 
 ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabihf/
 
+# Linux kernel cross compilation variables
+ENV PATH ${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE ${CROSS_TRIPLE}-
+ENV ARCH arm
+
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
 ARG IMAGE=dockcross/linux-armv7a

--- a/linux-mips/Dockerfile.in
+++ b/linux-mips/Dockerfile.in
@@ -29,6 +29,11 @@ ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 COPY Toolchain.cmake ${CROSS_ROOT}/
 ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
 
+# Linux kernel cross compilation variables
+ENV PATH ${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE ${CROSS_TRIPLE}-
+ENV ARCH mips
+
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
 ARG IMAGE=dockcross/linux-mips

--- a/linux-mipsel/Dockerfile
+++ b/linux-mipsel/Dockerfile
@@ -32,6 +32,11 @@ ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${CROSS_ROOT}/libc/lib/${CRO
 COPY Toolchain.cmake ${CROSS_ROOT}/
 ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
 
+# Linux kernel cross compilation variables
+ENV PATH ${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE ${CROSS_TRIPLE}-
+ENV ARCH mips
+
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
 ARG IMAGE=dockcross/linux-mipsel

--- a/linux-ppc64le/Dockerfile
+++ b/linux-ppc64le/Dockerfile
@@ -40,6 +40,11 @@ WORKDIR /work
 COPY Toolchain.cmake /usr/lib/${CROSS_TRIPLE}/
 ENV CMAKE_TOOLCHAIN_FILE /usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
 
+# Linux kernel cross compilation variables
+ENV PATH ${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE ${CROSS_TRIPLE}-
+ENV ARCH powerpc
+
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
 ARG IMAGE=dockcross/linux-ppc64le

--- a/linux-s390x/Dockerfile.in
+++ b/linux-s390x/Dockerfile.in
@@ -29,6 +29,11 @@ ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 COPY Toolchain.cmake ${CROSS_ROOT}/
 ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
 
+# Linux kernel cross compilation variables
+ENV PATH ${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE ${CROSS_TRIPLE}-
+ENV ARCH s390
+
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
 ARG IMAGE=dockcross/linux-s390x

--- a/linux-x86/Dockerfile
+++ b/linux-x86/Dockerfile
@@ -36,6 +36,10 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
 COPY Toolchain.cmake /usr/lib/${CROSS_TRIPLE}/
 ENV CMAKE_TOOLCHAIN_FILE /usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
 
+# Linux kernel cross compilation variables
+ENV CROSS_COMPILE ${CROSS_TRIPLE}-
+ENV ARCH x86
+
 COPY linux32-entrypoint.sh /dockcross/
 ENTRYPOINT ["/dockcross/linux32-entrypoint.sh"]
 


### PR DESCRIPTION
Set the ARCH, CROSS_COMPILE and PATH variables to support Linux kernel
cross compilation.

ARCH is set according to:
https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/arch?h=v5.2.2

PATH is set to include the cross toolchain path, which is used by the
kernel Makefile.

CROSS_COMPILE is the CROSS_TRIPLE with a dash appended, as the kernel
Makefile uses it to invoke the toolchain utils.

To build the kernel, depending on the config, _libssl-dev_ and _libelf-dev_
are required. Those are not dealt in this commit as they are not
correlated to the environment variables.

Validated by build the kernel using default kernel config when possible,
otherwise randomly select a defconfig.

**arch** - **defconfig**
arm64 - defconfig
armv5 and armv5-musl - colibri_pxa270_defconfig
armv6 - bcm2835_defconfig
armv7 and armv7a- tegra_defconfig
*x86 - i386_defconfig
mips and mipsel - ath79_defconfig
ppc64le - wii_defconfig
s390x - defconfig
x64 - x86_64_defconfig

* x86 dockcross toolchain does not provide "ld" and compilation fails.

fix #160