### PR TITLE
Feature threaded build

### DIFF
--- a/common.windows
+++ b/common.windows
@@ -15,8 +15,8 @@
 #  ARG MXE_TARGET_LINK=shared
 #
 
-# mxe master 2019-02-27
-ARG MXE_GIT_TAG=2ce5587c94fc355b2c826c786a3ee018479d88d1
+# mxe master 2019-06-17
+ARG MXE_GIT_TAG=0567f17d34463abda1790957812c54e8c0cf59fe
 
 ENV CMAKE_TOOLCHAIN_FILE /usr/src/mxe/usr/${MXE_TARGET_ARCH}-w64-mingw32.${MXE_TARGET_LINK}${MXE_TARGET_THREAD}/share/cmake/mxe-conf.cmake
 

--- a/common.windows
+++ b/common.windows
@@ -95,7 +95,7 @@ RUN \
   # Build MXE
   #
   cd /usr/src/mxe && \
-  make -j$(nproc) && \
+  make JOBS=$(nproc) && \
   #
   # Cleanup: By keeping the MXE build system (Makefile, ...), derived images will be able to install
   #          additional packages.

--- a/common.windows
+++ b/common.windows
@@ -15,8 +15,8 @@
 #  ARG MXE_TARGET_LINK=shared
 #
 
-# mxe master 2019-06-17
-ARG MXE_GIT_TAG=0567f17d34463abda1790957812c54e8c0cf59fe
+# mxe master 2019-11-24
+ARG MXE_GIT_TAG=2efc4d06171da361f7f1718c7f8465f46d63b110
 
 ENV CMAKE_TOOLCHAIN_FILE /usr/src/mxe/usr/${MXE_TARGET_ARCH}-w64-mingw32.${MXE_TARGET_LINK}${MXE_TARGET_THREAD}/share/cmake/mxe-conf.cmake
 

--- a/common.windows
+++ b/common.windows
@@ -87,6 +87,7 @@ RUN \
   #
   cd /usr/src/mxe && \
   echo "MXE_TARGETS := ${MXE_TARGET_ARCH}-w64-mingw32.${MXE_TARGET_LINK}${MXE_TARGET_THREAD}" > settings.mk && \
+  echo "MXE_USE_CCACHE :="                                                       >> settings.mk && \
   echo "LOCAL_PKG_LIST := cc cmake"                                              >> settings.mk && \
   echo ".DEFAULT local-pkg-list:"                                                >> settings.mk && \
   echo "local-pkg-list: \$(LOCAL_PKG_LIST)"                                      >> settings.mk && \


### PR DESCRIPTION
On top of #356, a simple change to the build process.

It seems specifying `JOBS=$(nproc)` makes all threads build a single package, which was a bit faster in my experience in a cloud build with many more package to be built than listed here.