### PR TITLE
add support for manylinux2014-x64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -385,6 +385,26 @@ jobs:
       - save_cache:
           key: manylinux2010-x86-assets-{{ .Revision }}
           paths: ~/docker/manylinux2010-x86.tar
+  manylinux2014-x64:
+    <<: *build-settings
+    steps:
+      - restore_cache:
+          key: base-assets-{{ .Revision }}
+      - run:
+         name: manylinux2014-x64 build
+         no_output_timeout: 1.5h
+         command: |
+           docker load -i ~/docker/base.tar
+           make manylinux2014-x64
+           tagged=$(docker images -q -f 'since=dockcross/manylinux2014-x64:latest' --format '{{.Repository}}:{{.Tag}}' | grep manylinux2014-x64)
+           docker save -o ~/docker/manylinux2014-x64.tar dockcross/manylinux2014-x64:latest $tagged
+      - run:
+         name: manylinux2014-x64 test
+         command: |
+           make manylinux2014-x64.test
+      - save_cache:
+          key: manylinux2014-x64-assets-{{ .Revision }}
+          paths: ~/docker/manylinux2014-x64.tar
   windows-static-x64:
     <<: *build-settings
     steps:
@@ -712,6 +732,18 @@ jobs:
               docker push $tagged
             fi
       - restore_cache:
+          key: manylinux2014-x64-assets-{{ .Revision }}
+      - deploy:
+          name: Deploy manylinux2014-x64
+          command: |
+            docker load -i ~/docker/manylinux2014-x64.tar
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              docker login -u $DOCKER_USER -p $DOCKER_PASS
+              docker push dockcross/manylinux2014-x64:latest
+              tagged=$(docker images -q -f 'since=dockcross/manylinux2014-x64:latest' --format '{{.Repository}}:{{.Tag}}' | grep manylinux2014-x64)
+              docker push $tagged
+            fi
+      - restore_cache:
           key: windows-static-x64-assets-{{ .Revision }}
       - deploy:
           name: Deploy windows-static-x64
@@ -841,6 +873,9 @@ workflows:
         - manylinux2010-x86:
             requires:
               - base
+        - manylinux2014-x64:
+            requires:
+              - base
         - windows-static-x64:
             requires:
               - base
@@ -879,6 +914,7 @@ workflows:
               - manylinux1-x86
               - manylinux2010-x64
               - manylinux2010-x86
+              - manylinux2014-x64
               - windows-static-x64
               - windows-static-x64-posix
               - windows-static-x86

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@ BIN = ./bin
 STANDARD_IMAGES = linux-s390x android-arm android-arm64 linux-x86 linux-x64 linux-arm64 linux-armv5 linux-armv5-musl linux-armv6 linux-armv7 linux-armv7a linux-mips linux-mipsel linux-ppc64le windows-static-x86 windows-static-x64 windows-static-x64-posix windows-shared-x86 windows-shared-x64 windows-shared-x64-posix
 
 # Generated Dockerfiles.
-GEN_IMAGES = linux-s390x linux-mips manylinux1-x64 manylinux1-x86 manylinux2010-x64 manylinux2010-x86 web-wasm linux-arm64 windows-static-x86 windows-static-x64 windows-static-x64-posix windows-shared-x86 windows-shared-x64 windows-shared-x64-posix linux-armv7 linux-armv7a linux-armv5 linux-armv5-musl linux-ppc64le
+GEN_IMAGES = linux-s390x linux-mips manylinux1-x64 manylinux1-x86 manylinux2010-x64 manylinux2010-x86 manylinux2014-x64 web-wasm linux-arm64 windows-static-x86 windows-static-x64 windows-static-x64-posix windows-shared-x86 windows-shared-x64 windows-shared-x64-posix linux-armv7 linux-armv7a linux-armv5 linux-armv5-musl linux-ppc64le
 GEN_IMAGE_DOCKERFILES = $(addsuffix /Dockerfile,$(GEN_IMAGES))
 
 # These images are expected to have explicit rules for *both* build and testing
-NON_STANDARD_IMAGES = web-wasm manylinux1-x64 manylinux1-x86 manylinux2010-x64 manylinux2010-x86
+NON_STANDARD_IMAGES = web-wasm manylinux1-x64 manylinux1-x86 manylinux2010-x64 manylinux2010-x86 manylinux2014-x64
 
 DOCKER_COMPOSITE_SOURCES = common.docker common.debian common.manylinux common.crosstool common.windows
 
@@ -96,6 +96,30 @@ web-wasm.test: web-wasm
 	$(DOCKER) run $(RM) dockcross/web-wasm > $(BIN)/dockcross-web-wasm && chmod +x $(BIN)/dockcross-web-wasm
 	$(BIN)/dockcross-web-wasm python test/run.py --exe-suffix ".js"
 	rm -rf web-wasm/test
+
+#
+# manylinux2014-x64
+#
+manylinux2014-x64: manylinux2014-x64/Dockerfile
+	mkdir -p $@/imagefiles && cp -r imagefiles $@/
+	$(DOCKER) build -t $(ORG)/manylinux2014-x64:latest \
+		--build-arg IMAGE=$(ORG)/manylinux2014-x64 \
+		--build-arg VCS_REF=`git rev-parse --short HEAD` \
+		--build-arg VCS_URL=`git config --get remote.origin.url` \
+		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+		-f manylinux2014-x64/Dockerfile .
+	$(DOCKER) build -t $(ORG)/manylinux2014-x64:$(TAG) \
+		--build-arg IMAGE=$(ORG)/manylinux2014-x64 \
+		--build-arg VERSION=$(TAG) \
+		--build-arg VCS_REF=`git rev-parse --short HEAD` \
+		--build-arg VCS_URL=`git config --get remote.origin.url` \
+		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+		-f manylinux2014-x64/Dockerfile .
+	rm -rf $@/imagefiles
+
+manylinux2014-x64.test: manylinux2014-x64
+	$(DOCKER) run $(RM) dockcross/manylinux2014-x64 > $(BIN)/dockcross-manylinux2014-x64 && chmod +x $(BIN)/dockcross-manylinux2014-x64
+	$(BIN)/dockcross-manylinux2014-x64 /opt/python/cp35-cp35m/bin/python test/run.py
 
 #
 # manylinux2010-x64

--- a/README.rst
+++ b/README.rst
@@ -189,6 +189,14 @@ dockcross/linux-x86
   |linux-x86-images| Linux i686 cross compiler.
 
 
+.. |manylinux2014-x64-images| image:: https://images.microbadger.com/badges/image/dockcross/manylinux2014-x64.svg
+  :target: https://microbadger.com/images/dockcross/manylinux2014-x64
+
+dockcross/manylinux2014-x64
+  |manylinux2014-x64-images| Docker `manylinux2014 <https://github.com/pypa/manylinux>`_ image for building Linux x86_64 / amd64 `Python wheel packages <http://pythonwheels.com/>`_. It includes Python 2.7, 3.4, 3.5, 3.6, 3.7 and 3.8.
+  Also has support for the dockcross script, and it has installations of CMake, Ninja, and `scikit-build <http://scikit-build.org>`_. For CMake, it sets `MANYLINUX2014` to "TRUE" in the toolchain.
+
+
 .. |manylinux2010-x64-images| image:: https://images.microbadger.com/badges/image/dockcross/manylinux2010-x64.svg
   :target: https://microbadger.com/images/dockcross/manylinux2010-x64
 

--- a/manylinux2014-x64/Dockerfile.in
+++ b/manylinux2014-x64/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux2014_x86_64
+FROM quay.io/pypa/manylinux2014_x86_64@sha256:4a5b19c57f38f59a85da695948f55bd690198a88c0df9273383f4e3fbeb457ba
 MAINTAINER Matt McCormick "matt.mccormick@kitware.com"
 
 ENV DEFAULT_DOCKCROSS_IMAGE dockcross/manylinux2014-x64

--- a/manylinux2014-x64/Dockerfile.in
+++ b/manylinux2014-x64/Dockerfile.in
@@ -1,0 +1,37 @@
+FROM quay.io/pypa/manylinux2014_x86_64
+MAINTAINER Matt McCormick "matt.mccormick@kitware.com"
+
+ENV DEFAULT_DOCKCROSS_IMAGE dockcross/manylinux2014-x64
+
+#include "common.manylinux"
+
+#include "common.docker"
+
+ENV CROSS_TRIPLE x86_64-linux-gnu
+ENV CROSS_ROOT /opt/rh/devtoolset-8/root/usr/bin
+ENV AS=${CROSS_ROOT}/as \
+    AR=${CROSS_ROOT}/ar \
+    CC=${CROSS_ROOT}/gcc \
+    CPP=${CROSS_ROOT}/cpp \
+    CXX=${CROSS_ROOT}/g++ \
+    LD=${CROSS_ROOT}/ld \
+    FC=${CROSS_ROOT}/gfortran
+
+COPY linux-x64/${CROSS_TRIPLE}-noop.sh /usr/bin/${CROSS_TRIPLE}-noop
+
+COPY manylinux2014-x64/Toolchain.cmake ${CROSS_ROOT}/../lib/
+ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/../lib/Toolchain.cmake
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG IMAGE=dockcross/manylinux2014-x64
+ARG VERSION=latest
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.version=$VERSION \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"
+ENV DEFAULT_DOCKCROSS_IMAGE ${IMAGE}:${VERSION}

--- a/manylinux2014-x64/Toolchain.cmake
+++ b/manylinux2014-x64/Toolchain.cmake
@@ -1,0 +1,11 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_CROSSCOMPILING FALSE)
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
+
+set(MANYLINUX2014 TRUE)
+
+set(CMAKE_C_COMPILER /opt/rh/devtoolset-8/root/usr/bin/gcc)
+set(CMAKE_CXX_COMPILER /opt/rh/devtoolset-8/root/usr/bin/g++)
+set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
+set(CMAKE_Fortran_COMPILER /opt/rh/devtoolset-8/root/usr/bin/gfortran)


### PR DESCRIPTION
This is bringing manylinux2014-x64 to dockcross.

#### A few notes:

* I naively copied the Dockerfile and Toolchain from manylinux2010.
* I use `FROM quay.io/pypa/manylinux2014_x86_64`, I don't know if I could/should fix that to a tag somehow.
* I checked all the paths against manylinux2014, and they all seemed valid as far as I could tell.
* I tried to build manylinux2014-x64 locally (`$ make manylinux2014-x64`).
* I tried to run the tests (`$ make manylinux2014-x64.test`), and it seems to me that they did not fail (output below).
* I built my project with my new manylinux2014-x64 image, and it ended up in an executable that runs on my linux machine and that does not link to dependencies I would not expect.

#### Output of `ldd` on my project built with dockcross-manylinux2014 (using CMake):

```
% ldd ./build/manylinux2014-x64/src/backend/src/mavsdk_server                                                                                   [130]
	linux-vdso.so.1 (0x00007ffe36f92000)
	libpthread.so.0 => /usr/lib/libpthread.so.0 (0x00007f5b8884a000)
	libnsl.so.1 => /usr/lib/libnsl.so.1 (0x00007f5b8882f000)
	libdl.so.2 => /usr/lib/libdl.so.2 (0x00007f5b8882a000)
	librt.so.1 => /usr/lib/librt.so.1 (0x00007f5b8881f000)
	libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007f5b88635000)
	libm.so.6 => /usr/lib/libm.so.6 (0x00007f5b884ef000)
	libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007f5b884d3000)
	libc.so.6 => /usr/lib/libc.so.6 (0x00007f5b8830c000)
	/lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x00007f5b888ac000)
```

#### Output of `$ make manylinux2014-x64.test`:

```
rm -rf manylinux2014-x64/imagefiles
mkdir -p ./bin
docker run --rm dockcross/manylinux2014-x64 > ./bin/dockcross-manylinux2014-x64 && chmod +x ./bin/dockcross-manylinux2014-x64
./bin/dockcross-manylinux2014-x64 /opt/python/cp35-cp35m/bin/python test/run.py


--------------------------------------------------------
Testing None build system with the C language

Building /work/test/C/hello.c by calling /opt/rh/devtoolset-8/root/usr/bin/gcc...
/opt/rh/devtoolset-8/root/usr/bin/gcc /work/test/C/hello.c -o a.out
Deleting temporary build directory /tmp/tmpf0ubift8


--------------------------------------------------------
Testing CMake build system with the C language

Building /work/test/C/hello.c with CMake...
cmake ..
-- The C compiler identification is GNU 8.3.1
-- The CXX compiler identification is GNU 8.3.1
-- Check for working C compiler: /opt/rh/devtoolset-8/root/usr/bin/gcc
-- Check for working C compiler: /opt/rh/devtoolset-8/root/usr/bin/gcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /opt/rh/devtoolset-8/root/usr/bin/g++
-- Check for working CXX compiler: /opt/rh/devtoolset-8/root/usr/bin/g++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/tmpsmffigci/build
/usr/bin/cmake -S/tmp/tmpsmffigci -B/tmp/tmpsmffigci/build --check-build-system CMakeFiles/Makefile.cmake 0
/usr/bin/cmake -E cmake_progress_start /tmp/tmpsmffigci/build/CMakeFiles /tmp/tmpsmffigci/build/CMakeFiles/progress.marks
make -f CMakeFiles/Makefile2 all
make[1]: Entering directory `/tmp/tmpsmffigci/build'
make -f CMakeFiles/a.out.dir/build.make CMakeFiles/a.out.dir/depend
make[2]: Entering directory `/tmp/tmpsmffigci/build'
cd /tmp/tmpsmffigci/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /tmp/tmpsmffigci /tmp/tmpsmffigci /tmp/tmpsmffigci/build /tmp/tmpsmffigci/build /tmp/tmpsmffigci/build/CMakeFiles/a.out.dir/DependInfo.cmake --color=
Dependee "/tmp/tmpsmffigci/build/CMakeFiles/a.out.dir/DependInfo.cmake" is newer than depender "/tmp/tmpsmffigci/build/CMakeFiles/a.out.dir/depend.internal".
Dependee "/tmp/tmpsmffigci/build/CMakeFiles/CMakeDirectoryInformation.cmake" is newer than depender "/tmp/tmpsmffigci/build/CMakeFiles/a.out.dir/depend.internal".
Scanning dependencies of target a.out
make[2]: Leaving directory `/tmp/tmpsmffigci/build'
make -f CMakeFiles/a.out.dir/build.make CMakeFiles/a.out.dir/build
make[2]: Entering directory `/tmp/tmpsmffigci/build'
[ 50%] Building C object CMakeFiles/a.out.dir/hello.c.o
/opt/rh/devtoolset-8/root/usr/bin/gcc    -o CMakeFiles/a.out.dir/hello.c.o   -c /tmp/tmpsmffigci/hello.c
[100%] Linking C executable a.out
/usr/bin/cmake -E cmake_link_script CMakeFiles/a.out.dir/link.txt --verbose=1
/opt/rh/devtoolset-8/root/usr/bin/gcc   -rdynamic CMakeFiles/a.out.dir/hello.c.o  -o a.out 
make[2]: Leaving directory `/tmp/tmpsmffigci/build'
[100%] Built target a.out
make[1]: Leaving directory `/tmp/tmpsmffigci/build'
/usr/bin/cmake -E cmake_progress_start /tmp/tmpsmffigci/build/CMakeFiles 0
Deleting temporary build directory /tmp/tmpsmffigci


--------------------------------------------------------
Testing None build system with the C++ language

Building /work/test/C++/hello.cxx by calling /opt/rh/devtoolset-8/root/usr/bin/g++...
/opt/rh/devtoolset-8/root/usr/bin/g++ /work/test/C++/hello.cxx -o a.out
Deleting temporary build directory /tmp/tmpuyzap1l2


--------------------------------------------------------
Testing CMake build system with the C++ language

Building /work/test/C++/hello.cxx with CMake...
cmake ..
-- The C compiler identification is GNU 8.3.1
-- The CXX compiler identification is GNU 8.3.1
-- Check for working C compiler: /opt/rh/devtoolset-8/root/usr/bin/gcc
-- Check for working C compiler: /opt/rh/devtoolset-8/root/usr/bin/gcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /opt/rh/devtoolset-8/root/usr/bin/g++
-- Check for working CXX compiler: /opt/rh/devtoolset-8/root/usr/bin/g++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/tmpclpdhazh/build
/usr/bin/cmake -S/tmp/tmpclpdhazh -B/tmp/tmpclpdhazh/build --check-build-system CMakeFiles/Makefile.cmake 0
/usr/bin/cmake -E cmake_progress_start /tmp/tmpclpdhazh/build/CMakeFiles /tmp/tmpclpdhazh/build/CMakeFiles/progress.marks
make -f CMakeFiles/Makefile2 all
make[1]: Entering directory `/tmp/tmpclpdhazh/build'
make -f CMakeFiles/a.out.dir/build.make CMakeFiles/a.out.dir/depend
make[2]: Entering directory `/tmp/tmpclpdhazh/build'
cd /tmp/tmpclpdhazh/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /tmp/tmpclpdhazh /tmp/tmpclpdhazh /tmp/tmpclpdhazh/build /tmp/tmpclpdhazh/build /tmp/tmpclpdhazh/build/CMakeFiles/a.out.dir/DependInfo.cmake --color=
Dependee "/tmp/tmpclpdhazh/build/CMakeFiles/a.out.dir/DependInfo.cmake" is newer than depender "/tmp/tmpclpdhazh/build/CMakeFiles/a.out.dir/depend.internal".
Dependee "/tmp/tmpclpdhazh/build/CMakeFiles/CMakeDirectoryInformation.cmake" is newer than depender "/tmp/tmpclpdhazh/build/CMakeFiles/a.out.dir/depend.internal".
Scanning dependencies of target a.out
make[2]: Leaving directory `/tmp/tmpclpdhazh/build'
make -f CMakeFiles/a.out.dir/build.make CMakeFiles/a.out.dir/build
make[2]: Entering directory `/tmp/tmpclpdhazh/build'
[ 50%] Building CXX object CMakeFiles/a.out.dir/hello.cxx.o
/opt/rh/devtoolset-8/root/usr/bin/g++     -o CMakeFiles/a.out.dir/hello.cxx.o -c /tmp/tmpclpdhazh/hello.cxx
[100%] Linking CXX executable a.out
/usr/bin/cmake -E cmake_link_script CMakeFiles/a.out.dir/link.txt --verbose=1
/opt/rh/devtoolset-8/root/usr/bin/g++    -rdynamic CMakeFiles/a.out.dir/hello.cxx.o  -o a.out 
make[2]: Leaving directory `/tmp/tmpclpdhazh/build'
[100%] Built target a.out
make[1]: Leaving directory `/tmp/tmpclpdhazh/build'
/usr/bin/cmake -E cmake_progress_start /tmp/tmpclpdhazh/build/CMakeFiles 0
Deleting temporary build directory /tmp/tmpclpdhazh
```

Resolves #358.