### PR TITLE
Add manylinux2010-x86

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -838,6 +838,9 @@ workflows:
         - manylinux2010-x64:
             requires:
               - base
+        - manylinux2010-x86:
+            requires:
+              - base
         - windows-static-x64:
             requires:
               - base
@@ -875,6 +878,7 @@ workflows:
               - manylinux1-x64
               - manylinux1-x86
               - manylinux2010-x64
+              - manylinux2010-x86
               - windows-static-x64
               - windows-static-x64-posix
               - windows-static-x86

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,6 +365,26 @@ jobs:
       - save_cache:
           key: manylinux2010-x64-assets-{{ .Revision }}
           paths: ~/docker/manylinux2010-x64.tar
+  manylinux2010-x86:
+    <<: *build-settings
+    steps:
+      - restore_cache:
+          key: base-assets-{{ .Revision }}
+      - run:
+         name: manylinux2010-x86 build
+         no_output_timeout: 1.5h
+         command: |
+           docker load -i ~/docker/base.tar
+           make manylinux2010-x86
+           tagged=$(docker images -q -f 'since=dockcross/manylinux2010-x86:latest' --format '{{.Repository}}:{{.Tag}}' | grep manylinux2010-x86)
+           docker save -o ~/docker/manylinux2010-x86.tar dockcross/manylinux2010-x86:latest $tagged
+      - run:
+         name: manylinux2010-x86 test
+         command: |
+           make manylinux2010-x86.test
+      - save_cache:
+          key: manylinux2010-x86-assets-{{ .Revision }}
+          paths: ~/docker/manylinux2010-x86.tar
   windows-static-x64:
     <<: *build-settings
     steps:

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@ BIN = ./bin
 STANDARD_IMAGES = linux-s390x android-arm android-arm64 linux-x86 linux-x64 linux-arm64 linux-armv5 linux-armv5-musl linux-armv6 linux-armv7 linux-armv7a linux-mips linux-mipsel linux-ppc64le windows-static-x86 windows-static-x64 windows-static-x64-posix windows-shared-x86 windows-shared-x64 windows-shared-x64-posix
 
 # Generated Dockerfiles.
-GEN_IMAGES = linux-s390x linux-mips manylinux1-x64 manylinux1-x86 manylinux2010-x64 web-wasm linux-arm64 windows-static-x86 windows-static-x64 windows-static-x64-posix windows-shared-x86 windows-shared-x64 windows-shared-x64-posix linux-armv7 linux-armv7a linux-armv5 linux-armv5-musl linux-ppc64le
+GEN_IMAGES = linux-s390x linux-mips manylinux1-x64 manylinux1-x86 manylinux2010-x64 manylinux2010-x86 web-wasm linux-arm64 windows-static-x86 windows-static-x64 windows-static-x64-posix windows-shared-x86 windows-shared-x64 windows-shared-x64-posix linux-armv7 linux-armv7a linux-armv5 linux-armv5-musl linux-ppc64le
 GEN_IMAGE_DOCKERFILES = $(addsuffix /Dockerfile,$(GEN_IMAGES))
 
 # These images are expected to have explicit rules for *both* build and testing
-NON_STANDARD_IMAGES = web-wasm manylinux1-x64 manylinux1-x86 manylinux2010-x64
+NON_STANDARD_IMAGES = web-wasm manylinux1-x64 manylinux1-x86 manylinux2010-x64 manylinux2010-x86
 
 DOCKER_COMPOSITE_SOURCES = common.docker common.debian common.manylinux common.crosstool common.windows
 
@@ -97,7 +97,6 @@ web-wasm.test: web-wasm
 	$(BIN)/dockcross-web-wasm python test/run.py --exe-suffix ".js"
 	rm -rf web-wasm/test
 
-
 #
 # manylinux2010-x64
 #
@@ -122,6 +121,31 @@ manylinux2010-x64: manylinux2010-x64/Dockerfile
 manylinux2010-x64.test: manylinux2010-x64
 	$(DOCKER) run $(RM) dockcross/manylinux2010-x64 > $(BIN)/dockcross-manylinux2010-x64 && chmod +x $(BIN)/dockcross-manylinux2010-x64
 	$(BIN)/dockcross-manylinux2010-x64 /opt/python/cp35-cp35m/bin/python test/run.py
+
+#
+# manylinux2010-x86
+#
+
+manylinux2010-x86: manylinux2010-x86/Dockerfile
+	mkdir -p $@/imagefiles && cp -r imagefiles $@/
+	$(DOCKER) build -t $(ORG)/manylinux2010-x86:latest \
+		--build-arg IMAGE=$(ORG)/manylinux2010-x86 \
+		--build-arg VCS_REF=`git rev-parse --short HEAD` \
+		--build-arg VCS_URL=`git config --get remote.origin.url` \
+		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+		-f manylinux2010-x86/Dockerfile .
+	$(DOCKER) build -t $(ORG)/manylinux2010-x86:$(TAG) \
+		--build-arg IMAGE=$(ORG)/manylinux2010-x86 \
+		--build-arg VERSION=$(TAG) \
+		--build-arg VCS_REF=`git rev-parse --short HEAD` \
+		--build-arg VCS_URL=`git config --get remote.origin.url` \
+		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+		-f manylinux2010-x86/Dockerfile .
+	rm -rf $@/imagefiles
+
+manylinux2010-x86.test: manylinux2010-x86
+	$(DOCKER) run $(RM) dockcross/manylinux2010-x86 > $(BIN)/dockcross-manylinux2010-x86 && chmod +x $(BIN)/dockcross-manylinux2010-x86
+	$(BIN)/dockcross-manylinux2010-x86 /opt/python/cp35-cp35m/bin/python test/run.py
 
 #
 # manylinux1-x64

--- a/README.rst
+++ b/README.rst
@@ -197,6 +197,14 @@ dockcross/manylinux2010-x64
   Also has support for the dockcross script, and it has installations of CMake, Ninja, and `scikit-build <http://scikit-build.org>`_. For CMake, it sets `MANYLINUX2010` to "TRUE" in the toolchain.
 
 
+.. |manylinux2010-x86-images| image:: https://images.microbadger.com/badges/image/dockcross/manylinux2010-x86.svg
+  :target: https://microbadger.com/images/dockcross/manylinux2010-x86
+
+dockcross/manylinux2010-x86
+  |manylinux2010-x86-images| Docker `manylinux2010 <https://github.com/pypa/manylinux>`_ image for building Linux i686 `Python wheel packages <http://pythonwheels.com/>`_. It includes Python 2.7, 3.4, 3.5, 3.6, 3.7 and 3.8.
+  Also has support for the dockcross script, and it has installations of CMake, Ninja, and `scikit-build <http://scikit-build.org>`_. For CMake, it sets `MANYLINUX2010` to "TRUE" in the toolchain.
+
+
 .. |manylinux1-x64-images| image:: https://images.microbadger.com/badges/image/dockcross/manylinux1-x64.svg
   :target: https://microbadger.com/images/dockcross/manylinux1-x64
 

--- a/common.docker
+++ b/common.docker
@@ -18,7 +18,7 @@ COPY \
   /buildscripts/
 
 RUN \
-  X86_FLAG=$([[ "$DEFAULT_DOCKCROSS_IMAGE" =~ dockcross/manylinux.*-x86 ]] && echo "-32" || echo "-XX") && \
+  X86_FLAG=$([ "$DEFAULT_DOCKCROSS_IMAGE" = "dockcross/manylinux1-x86" -o "$DEFAULT_DOCKCROSS_IMAGE" = "dockcross/manylinux2010-x86" ] && echo "-32" || echo "") && \
   /buildscripts/build-and-install-openssl.sh $X86_FLAG && \
   /buildscripts/build-and-install-openssh.sh && \
   /buildscripts/build-and-install-curl.sh && \

--- a/common.docker
+++ b/common.docker
@@ -18,7 +18,7 @@ COPY \
   /buildscripts/
 
 RUN \
-  X86_FLAG=$([ "$DEFAULT_DOCKCROSS_IMAGE" = "dockcross/manylinux1-x86" ] && echo "-32" || echo "") && \
+  X86_FLAG=$([[ "$DEFAULT_DOCKCROSS_IMAGE" =~ dockcross/manylinux.*-x86 ]] && echo "-32" || echo "-XX") && \
   /buildscripts/build-and-install-openssl.sh $X86_FLAG && \
   /buildscripts/build-and-install-openssh.sh && \
   /buildscripts/build-and-install-curl.sh && \

--- a/common.manylinux
+++ b/common.manylinux
@@ -23,6 +23,7 @@ RUN \
   # Remove sudo provided by "devtoolset-2" and "devtoolset-8" since it doesn't work with
   # our sudo wrapper calling gosu.
   rm -f /opt/rh/devtoolset-2/root/usr/bin/sudo && \
+  rm -f /opt/rh/devtoolset-7/root/usr/bin/sudo && \
   rm -f /opt/rh/devtoolset-8/root/usr/bin/sudo && \
   /buildscripts/install-python-packages.sh && \
   rm -rf /buildscripts

--- a/imagefiles/build-and-install-openssl.sh
+++ b/imagefiles/build-and-install-openssl.sh
@@ -54,7 +54,7 @@ OPENSSL_HASH=cabd5c9492825ce5bd23f3c3aeed6a97f8142f606d893df216411f07d1abab96
 # XXX: the official https server at www.openssl.org cannot be reached
 # with the old versions of openssl and curl in Centos 5.11 hence the fallback
 # to the ftp mirror:
-OPENSSL_DOWNLOAD_URL=ftp://ftp.openssl.org/source
+OPENSSL_DOWNLOAD_URL=https://ftp.openssl.org/source
 
 function do_openssl_build {
     ${WRAPPER} ./config no-ssl2 no-shared -fPIC $CONFIG_FLAG --prefix=/usr/local/ssl > /dev/null

--- a/imagefiles/build-and-install-openssl.sh
+++ b/imagefiles/build-and-install-openssl.sh
@@ -54,7 +54,7 @@ OPENSSL_HASH=cabd5c9492825ce5bd23f3c3aeed6a97f8142f606d893df216411f07d1abab96
 # XXX: the official https server at www.openssl.org cannot be reached
 # with the old versions of openssl and curl in Centos 5.11 hence the fallback
 # to the ftp mirror:
-OPENSSL_DOWNLOAD_URL=https://ftp.openssl.org/source
+OPENSSL_DOWNLOAD_URL=http://www.openssl.org/source/
 
 function do_openssl_build {
     ${WRAPPER} ./config no-ssl2 no-shared -fPIC $CONFIG_FLAG --prefix=/usr/local/ssl > /dev/null

--- a/manylinux2010-x64/Dockerfile.in
+++ b/manylinux2010-x64/Dockerfile.in
@@ -7,6 +7,11 @@ ENV DEFAULT_DOCKCROSS_IMAGE dockcross/manylinux2010-x64
 
 #include "common.docker"
 
+# Override yum to work around the problem with newly built libcurl.so.4
+# https://access.redhat.com/solutions/641093
+RUN echo $'#!/bin/bash\n\
+LD_PRELOAD=/usr/lib64/libcurl.so.4 /usr/bin/yum "$@"' > /usr/local/bin/yum && chmod a+x /usr/local/bin/yum
+
 ENV CROSS_TRIPLE x86_64-linux-gnu
 ENV CROSS_ROOT /opt/rh/devtoolset-8/root/usr/bin
 ENV AS=${CROSS_ROOT}/as \

--- a/manylinux2010-x86/Dockerfile.in
+++ b/manylinux2010-x86/Dockerfile.in
@@ -1,14 +1,14 @@
-FROM quay.io/pypa/manylinux2010_x86_64:latest
+FROM quay.io/pypa/manylinux2010_i686:latest
 MAINTAINER Matt McCormick "matt.mccormick@kitware.com"
 
-ENV DEFAULT_DOCKCROSS_IMAGE dockcross/manylinux2010-x64
+ENV DEFAULT_DOCKCROSS_IMAGE dockcross/manylinux2010-x86
 
 #include "common.manylinux"
 
 #include "common.docker"
 
-ENV CROSS_TRIPLE x86_64-linux-gnu
-ENV CROSS_ROOT /opt/rh/devtoolset-8/root/usr/bin
+ENV CROSS_TRIPLE i686-linux-gnu
+ENV CROSS_ROOT /opt/rh/devtoolset-7/root/usr/bin
 ENV AS=${CROSS_ROOT}/as \
     AR=${CROSS_ROOT}/ar \
     CC=${CROSS_ROOT}/gcc \
@@ -17,14 +17,17 @@ ENV AS=${CROSS_ROOT}/as \
     LD=${CROSS_ROOT}/ld \
     FC=${CROSS_ROOT}/gfortran
 
-COPY linux-x64/${CROSS_TRIPLE}-noop.sh /usr/bin/${CROSS_TRIPLE}-noop
+COPY linux-x86/${CROSS_TRIPLE}-noop.sh /usr/bin/${CROSS_TRIPLE}-noop
 
-COPY manylinux2010-x64/Toolchain.cmake ${CROSS_ROOT}/../lib/
+COPY manylinux2010-x86/Toolchain.cmake ${CROSS_ROOT}/../lib/
 ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/../lib/Toolchain.cmake
+
+COPY linux-x86/linux32-entrypoint.sh /dockcross/
+ENTRYPOINT ["/dockcross/linux32-entrypoint.sh"]
 
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
-ARG IMAGE=dockcross/manylinux2010-x64
+ARG IMAGE=dockcross/manylinux2010-x86
 ARG VERSION=latest
 ARG VCS_REF
 ARG VCS_URL

--- a/manylinux2010-x86/Dockerfile.in
+++ b/manylinux2010-x86/Dockerfile.in
@@ -7,6 +7,11 @@ ENV DEFAULT_DOCKCROSS_IMAGE dockcross/manylinux2010-x86
 
 #include "common.docker"
 
+# Override yum to work around the problem with newly built libcurl.so.4
+# https://access.redhat.com/solutions/641093
+RUN echo $'#!/bin/bash\n\
+LD_PRELOAD=/usr/lib/libcurl.so.4 /usr/bin/yum "$@"' > /usr/local/bin/yum && chmod a+x /usr/local/bin/yum
+
 ENV CROSS_TRIPLE i686-linux-gnu
 ENV CROSS_ROOT /opt/rh/devtoolset-7/root/usr/bin
 ENV AS=${CROSS_ROOT}/as \

--- a/manylinux2010-x86/Toolchain.cmake
+++ b/manylinux2010-x86/Toolchain.cmake
@@ -1,0 +1,11 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_CROSSCOMPILING FALSE)
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR i686)
+
+set(MANYLINUX2010 TRUE)
+
+set(CMAKE_C_COMPILER /opt/rh/devtoolset-7/root/usr/bin/gcc)
+set(CMAKE_CXX_COMPILER /opt/rh/devtoolset-7/root/usr/bin/g++)
+set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
+set(CMAKE_Fortran_COMPILER /opt/rh/devtoolset-7/root/usr/bin/gfortran)


### PR DESCRIPTION
Added `dockcross/manylinux2010-x86` as official [manylinux2010-x86](https://quay.io/repository/pypa/manylinux2010_i686) came out.
Updated `dockcross/manylinux2010-x64` to use official upstream base [docker image](https://quay.io/repository/pypa/manylinux2010_x86_64).