### PR TITLE
Changed the version of gcc for mxe to 9

### DIFF
--- a/common.windows
+++ b/common.windows
@@ -88,6 +88,7 @@ RUN \
   cd /usr/src/mxe && \
   echo "MXE_TARGETS := ${MXE_TARGET_ARCH}-w64-mingw32.${MXE_TARGET_LINK}${MXE_TARGET_THREAD}" > settings.mk && \
   echo "MXE_USE_CCACHE :="                                                       >> settings.mk && \
+  echo "MXE_PLUGIN_DIRS := plugins/gcc9"                                         >> settings.mk && \
   echo "LOCAL_PKG_LIST := cc cmake"                                              >> settings.mk && \
   echo ".DEFAULT local-pkg-list:"                                                >> settings.mk && \
   echo "local-pkg-list: \$(LOCAL_PKG_LIST)"                                      >> settings.mk && \


### PR DESCRIPTION
The default version of gcc for mxe is 5 which is too stale to support C++17. Let's bump the version of gcc to 9 to gain all the benefit that the recent gcc provides such as C++17 support and performance optimization ([changes](https://gcc.gnu.org/gcc-9/changes.html)).