### PR TITLE
doc: Note that yum addressed in recent manylinux2014-x64

### DIFF
--- a/manylinux2014-x64/Dockerfile.in
+++ b/manylinux2014-x64/Dockerfile.in
@@ -1,3 +1,4 @@
+# Recent versions address yum functionality
 FROM quay.io/pypa/manylinux2014_x86_64:latest
 MAINTAINER Matt McCormick "matt.mccormick@kitware.com"
 


### PR DESCRIPTION
This patch is intended to trigger a build / deploy based on the latest
upstream manylinux2014-x64 image.