### PR TITLE
manylinux2014-x64: Add yum libcurl workaround

### DIFF
--- a/manylinux2014-x64/Dockerfile.in
+++ b/manylinux2014-x64/Dockerfile.in
@@ -7,6 +7,11 @@ ENV DEFAULT_DOCKCROSS_IMAGE dockcross/manylinux2014-x64
 
 #include "common.docker"
 
+# Override yum to work around the problem with newly built libcurl.so.4
+# https://access.redhat.com/solutions/641093
+RUN echo $'#!/bin/bash\n\
+LD_PRELOAD=/usr/lib64/libcurl.so.4 /usr/bin/yum "$@"' > /usr/local/bin/yum && chmod a+x /usr/local/bin/yum
+
 ENV CROSS_TRIPLE x86_64-linux-gnu
 ENV CROSS_ROOT /opt/rh/devtoolset-8/root/usr/bin
 ENV AS=${CROSS_ROOT}/as \


### PR DESCRIPTION
Based on the manylinux2010 workaround.