### PR TITLE
base: Update CMake from 3.13.2 to 3.16.5

### DIFF
--- a/common.docker
+++ b/common.docker
@@ -1,7 +1,7 @@
 WORKDIR /usr/src
 
 ARG GIT_VERSION=2.22.0
-ARG CMAKE_VERSION=3.13.2
+ARG CMAKE_VERSION=3.16.5
 
 # Image build scripts
 COPY \


### PR DESCRIPTION
To be conservative, I only updated to use 3.16.5

That said, version 3.17.0 is also available as a dockerbuild release as well. See https://github.com/dockbuild/CMake/releases