### PR TITLE
[linux-arm64] bump up the version of gcc to 8

### DIFF
--- a/linux-arm64/crosstool-ng.config
+++ b/linux-arm64/crosstool-ng.config
@@ -7,6 +7,7 @@ CT_CONFIGURE_has_wget=y
 CT_CONFIGURE_has_curl=y
 CT_CONFIGURE_has_stat_flavor_GNU=y
 CT_CONFIGURE_has_make_3_81_or_newer=y
+CT_CONFIGURE_has_libtool_2_4_or_newer=y
 CT_CONFIGURE_has_libtoolize_2_4_or_newer=y
 CT_CONFIGURE_has_autoconf_2_63_or_newer=y
 CT_CONFIGURE_has_autoreconf_2_63_or_newer=y
@@ -301,14 +302,14 @@ CT_BINUTILS_EXTRA_CONFIG_ARRAY=""
 # C-library
 #
 CT_LIBC="glibc"
-CT_LIBC_VERSION="2.25"
+CT_LIBC_VERSION="2.27"
 CT_LIBC_glibc=y
 # CT_LIBC_uClibc is not set
 CT_LIBC_avr_libc_AVAILABLE=y
 CT_LIBC_glibc_AVAILABLE=y
 CT_THREADS="nptl"
-# CT_CC_GLIBC_SHOW_LINARO is not set
-CT_LIBC_GLIBC_V_2_25=y
+CT_CC_GLIBC_SHOW_LINARO=y
+# CT_LIBC_GLIBC_V_2_25 is not set
 # CT_LIBC_GLIBC_V_2_24 is not set
 # CT_LIBC_GLIBC_V_2_23 is not set
 CT_LIBC_GLIBC_2_23_or_later=y
@@ -355,14 +356,16 @@ CT_CC_CORE_PASSES_NEEDED=y
 CT_CC_CORE_PASS_1_NEEDED=y
 CT_CC_CORE_PASS_2_NEEDED=y
 CT_CC_gcc=y
-CT_CC_GCC_VERSION="4.9.4"
+CT_CC_GCC_VERSION="8.3.0"
 # CT_CC_GCC_SHOW_LINARO is not set
-# CT_CC_GCC_V_6_3_0 is not set
+CT_CC_GCC_V_6_3_0=y
 # CT_CC_GCC_V_5_4_0 is not set
-CT_CC_GCC_V_4_9_4=y
+# CT_CC_GCC_V_4_9_4 is not set
 CT_CC_GCC_4_8_or_later=y
-CT_CC_GCC_4_9=y
 CT_CC_GCC_4_9_or_later=y
+CT_CC_GCC_5_or_later=y
+CT_CC_GCC_6=y
+CT_CC_GCC_6_or_later=y
 CT_CC_GCC_ENABLE_PLUGINS=y
 CT_CC_GCC_GOLD=y
 CT_CC_GCC_ENABLE_CXX_FLAGS=""
@@ -439,8 +442,8 @@ CT_GDB_GDBSERVER_HAS_IPA_LIB=y
 #
 # gdb version
 #
-CT_GDB_VERSION="7.12.1"
-CT_GDB_V_7_12_1=y
+CT_GDB_VERSION="8.1"
+# CT_GDB_V_7_12_1 is not set
 # CT_GDB_V_7_11_1 is not set
 CT_GDB_7_12_or_later=y
 CT_GDB_7_2_or_later=y


### PR DESCRIPTION
linux-arm64 is currently using gcc 4, so it's difficult to take
advantage of modern C++. This PR bump up the version of gcc to
allow us to enjoy all the benefits of modern C++. (This PR is based
on #310)