### PR TITLE
Add support for manylinux2014-aarch64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -764,9 +764,9 @@ jobs:
               docker push $tagged
             fi
       - restore_cache:
-          keys: 
-            - manylinux2014-x64-assets-{{ .Revision }}
-            - manylinux2014-aarch64-assets-{{ .Revision }}
+          key: manylinux2014-x64-assets-{{ .Revision }}
+      - restore_cache:
+          key: manylinux2014-aarch64-assets-{{ .Revision }}
       - deploy:
           name: Deploy manylinux2014-aarch64
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -405,6 +405,26 @@ jobs:
       - save_cache:
           key: manylinux2014-x64-assets-{{ .Revision }}
           paths: ~/docker/manylinux2014-x64.tar
+  manylinux2014-aarch64:
+    <<: *build-settings
+    steps:
+      - restore_cache:
+          key: base-assets-{{ .Revision }}
+      - run:
+         name: manylinux2014-aarch64 build
+         no_output_timeout: 1.5h
+         command: |
+           docker load -i ~/docker/base.tar
+           make manylinux2014-aarch64
+           tagged=$(docker images -q -f 'since=dockcross/manylinux2014-aarch64:latest' --format '{{.Repository}}:{{.Tag}}' | grep manylinux2014-aarch64)
+           docker save -o ~/docker/manylinux2014-aarch64.tar dockcross/manylinux2014-aarch64:latest $tagged
+      - run:
+         name: manylinux2014-aarch64 test
+         command: |
+           make manylinux2014-aarch64.test
+      - save_cache:
+          key: manylinux2014-aarch64-assets-{{ .Revision }}
+          paths: ~/docker/manylinux2014-aarch64.tar
   windows-static-x64:
     <<: *build-settings
     steps:
@@ -744,6 +764,21 @@ jobs:
               docker push $tagged
             fi
       - restore_cache:
+          keys: 
+            - manylinux2014-x64-assets-{{ .Revision }}
+            - manylinux2014-aarch64-assets-{{ .Revision }}
+      - deploy:
+          name: Deploy manylinux2014-aarch64
+          command: |
+            docker load -i ~/docker/manylinux2014-x64.tar
+            docker load -i ~/docker/manylinux2014-aarch64.tar
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              docker login -u $DOCKER_USER -p $DOCKER_PASS
+              docker push dockcross/manylinux2014-aarch64:latest
+              tagged=$(docker images -q -f 'since=dockcross/manylinux2014-aarch64:latest' --format '{{.Repository}}:{{.Tag}}' | grep manylinux2014-aarch64)
+              docker push $tagged
+            fi
+      - restore_cache:
           key: windows-static-x64-assets-{{ .Revision }}
       - deploy:
           name: Deploy windows-static-x64
@@ -876,6 +911,10 @@ workflows:
         - manylinux2014-x64:
             requires:
               - base
+        - manylinux2014-aarch64:
+            requires:
+              - base
+              - manylinux2014-x64
         - windows-static-x64:
             requires:
               - base
@@ -915,6 +954,7 @@ workflows:
               - manylinux2010-x64
               - manylinux2010-x86
               - manylinux2014-x64
+              - manylinux2014-aarch64
               - windows-static-x64
               - windows-static-x64-posix
               - windows-static-x86

--- a/README.rst
+++ b/README.rst
@@ -197,6 +197,14 @@ dockcross/manylinux2014-x64
   Also has support for the dockcross script, and it has installations of CMake, Ninja, and `scikit-build <http://scikit-build.org>`_. For CMake, it sets `MANYLINUX2014` to "TRUE" in the toolchain.
 
 
+.. |manylinux2014-aarch64-images| image:: https://images.microbadger.com/badges/image/dockcross/manylinux2014-aarch64.svg
+  :target: https://microbadger.com/images/dockcross/manylinux2014-aarch64
+
+dockcross/manylinux2014-aarch64
+  |manylinux2014-aarch64-images| Docker `manylinux2014 <https://github.com/pypa/manylinux>`_ image for building Linux aarch64 / arm64 `Python wheel packages <http://pythonwheels.com/>`_. It includes Python 2.7, 3.4, 3.5, 3.6, 3.7 and 3.8.
+  Also has support for the dockcross script, and it has installations of CMake, Ninja, and `scikit-build <http://scikit-build.org>`_. For CMake, it sets `MANYLINUX2014` to "TRUE" in the toolchain.
+
+
 .. |manylinux2010-x64-images| image:: https://images.microbadger.com/badges/image/dockcross/manylinux2010-x64.svg
   :target: https://microbadger.com/images/dockcross/manylinux2010-x64
 

--- a/common-manylinux.crosstool
+++ b/common-manylinux.crosstool
@@ -1,0 +1,63 @@
+# crosstool.common-manylinux
+#
+# Common Docker instructions to install "crosstool-ng" and build a full
+# cross-compiler suite from a crosstool-ng configuration, CROSSTOOL_CONFIG.
+#
+# This import complements the "dockcross/base" image, adding:
+# - "ct-ng", a cross-compiler building utilty.
+# - A cross-compiler suite configured in "crosstool-ng.config".
+#
+# The generated cross-compiler will have a CROSS_ROOT of:
+#   ${XCC_PREFIX}/${CROSS_TRIPLE}
+#
+# A given platform will need to supply the appropriate "crosstool-ng.config" to
+# generate its cross-compiler. This can be built using "ct-ng menuconfig" to
+# generate a configuration.
+
+ENV MANYLINUX_DEPS="glibc-devel glibc-devel.i686 libstdc++-devel glib2-devel libX11-devel libXext-devel libXrender-devel mesa-libGL-devel libICE-devel libSM-devel"
+
+ENV PYTHON_COMPILE_DEPS="python-devel zlib-devel bzip2-devel expat-devel ncurses-devel readline-devel tk-devel gdbm-devel libdb-devel libpcap-devel xz-devel openssl-devel keyutils-libs-devel krb5-devel libcom_err-devel libidn-devel curl-devel perl-devel"
+
+ENV TOOLCHAIN_DEPS="devtoolset-9-binutils devtoolset-9-gcc devtoolset-9-gcc-c++ devtoolset-9-gcc-gfortran"
+
+# Install dependent packages required for `ct-ng`.
+RUN \
+  yum -y update && \
+  yum -y install \
+    gawk \
+    gperf \
+    help2man \
+    texinfo \
+    flex \
+    ncurses-devel \
+    glibc-static \
+    systemtap-devel \
+    systemtap-sdt-devel \
+    ${TOOLCHAIN_DEPS} \
+    ${PYTHON_COMPILE_DEPS} \
+    ${MANYLINUX_DEPS} && \
+  yum clean all
+
+ENV XCC_PREFIX=/usr/xcc
+
+# Add the crosstool-ng script and image-specific toolchain configuration into
+# /dockcross/.
+#
+# Afterwards, we will leave the "ct-ng" config in the image as a reference
+# for users.
+COPY \
+  imagefiles/install-crosstool-ng-toolchain.sh \
+  manylinux2014-aarch64/crosstool-ng.config \
+  /dockcross/
+
+# Build and install the toolchain, cleaning up artifacts afterwards.
+RUN \
+  mkdir /dockcross/crosstool && \
+  cd /dockcross/crosstool && \
+  /dockcross/install-crosstool-ng-toolchain.sh \
+  -p "${XCC_PREFIX}" \
+  -c /dockcross/crosstool-ng.config && \
+  rm -rf /dockcross/crosstool /dockcross/install-crosstool-ng-toolchain.sh
+
+# Restore our default workdir (from "dockcross/base").
+WORKDIR /work

--- a/imagefiles/install-crosstool-ng-toolchain.sh
+++ b/imagefiles/install-crosstool-ng-toolchain.sh
@@ -90,5 +90,10 @@ cd "${BUILD}"
 
 cp "${CONFIG_PATH}" "${BUILD}/.config"
 
+
+# As mentioned in ct-ng config, need to unset LD_LIBRARY_PATH.
+unset LD_LIBRARY_PATH
+
 # Build and install the toolchain!
 "${BOOTSTRAP_PREFIX}/bin/ct-ng" build
+

--- a/imagefiles/install-liquidprompt-binary.sh
+++ b/imagefiles/install-liquidprompt-binary.sh
@@ -9,6 +9,9 @@ fi
 
 cd /usr/share
 
+# Remove liquidprompt if exists
+rm -rf liquidprompt
+
 git clone "https://github.com/nojhan/liquidprompt.git" -b v_1.11
 
 cat << EOF >> /root/.bashrc

--- a/manylinux2014-aarch64/Dockerfile.in
+++ b/manylinux2014-aarch64/Dockerfile.in
@@ -1,5 +1,8 @@
-# For manylinux2014-aarch64, cross-compilation will be hosted at x86_64 using manylinux2014 x86_64 image to generate target for aarch64. Toolchain available at  https://github.com/pypa/manylinux/blob/manylinux2014/docker/Dockerfile-aarch64, is for host aarch64.
-FROM dockcross/manylinux2014-x64 
+# manylinux2014-aarch64 is based on manylinux2014-x64 and the aarch64 toolchain installed. This allows to
+# run the container on a x86_64 host.
+# This image is not based on "pypa/manylinux2014_aarch64" because it would require the host to be aarch64.
+# For more details, read https://github.com/dockcross/dockcross/issues/367
+FROM dockcross/manylinux2014-x64
 
 # This is for 64-bit ARM Manylinux machine
 

--- a/manylinux2014-aarch64/Dockerfile.in
+++ b/manylinux2014-aarch64/Dockerfile.in
@@ -1,0 +1,53 @@
+# For manylinux2014-aarch64, cross-compilation will be hosted at x86_64 using manylinux2014 x86_64 image to generate target for aarch64. Toolchain available at  https://github.com/pypa/manylinux/blob/manylinux2014/docker/Dockerfile-aarch64, is for host aarch64.
+FROM dockcross/manylinux2014-x64 
+
+# This is for 64-bit ARM Manylinux machine
+
+#include "common-manylinux.crosstool"
+
+# The cross-compiling emulator
+RUN \
+  yum update && \
+  yum -y install \
+    qemu-user \
+    qemu-system-arm && \
+  yum clean all
+
+# The CROSS_TRIPLE is a configured alias of the "aarch64-unknown-linux-gnueabi" target.
+ENV CROSS_TRIPLE aarch64-unknown-linux-gnueabi
+
+ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
+    AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
+    CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
+    CPP=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-cpp \
+    CXX=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-g++ \
+    LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
+    FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
+
+ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+
+COPY manylinux2014-aarch64/Toolchain.cmake ${CROSS_ROOT}/
+ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+
+ENV PKG_CONFIG_PATH /usr/lib/aarch64-linux-gnu/pkgconfig
+
+# Linux kernel cross compilation variables
+ENV PATH ${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE ${CROSS_TRIPLE}-
+ENV ARCH arm64
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG IMAGE=dockcross/manylinux2014-aarch64
+ARG VERSION=latest
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.version=$VERSION \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"
+ENV DEFAULT_DOCKCROSS_IMAGE ${IMAGE}:${VERSION}

--- a/manylinux2014-aarch64/Toolchain.cmake
+++ b/manylinux2014-aarch64/Toolchain.cmake
@@ -1,0 +1,21 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+set(MANYLINUX2014 TRUE)
+
+set(cross_triple "aarch64-unknown-linux-gnueabi")
+set(cross_root /usr/xcc/${cross_triple})
+
+set(CMAKE_C_COMPILER $ENV{CC})
+set(CMAKE_CXX_COMPILER $ENV{CXX})
+set(CMAKE_Fortran_COMPILER $ENV{FC})
+
+set(CMAKE_CXX_FLAGS "-I ${cross_root}/include/")
+
+set(CMAKE_FIND_ROOT_PATH ${cross_root} ${cross_root}/${cross_triple})
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)
+set(CMAKE_SYSROOT ${cross_root}/${cross_triple}/sysroot)
+
+set(CMAKE_CROSSCOMPILING_EMULATOR /usr/bin/qemu-aarch64)

--- a/manylinux2014-aarch64/crosstool-ng.config
+++ b/manylinux2014-aarch64/crosstool-ng.config
@@ -1,0 +1,530 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Crosstool-NG Configuration
+#
+CT_CONFIGURE_has_static_link=y
+CT_CONFIGURE_has_wget=y
+CT_CONFIGURE_has_curl=y
+CT_CONFIGURE_has_stat_flavor_GNU=y
+CT_CONFIGURE_has_make_3_81_or_newer=y
+CT_CONFIGURE_has_libtool_2_4_or_newer=y
+CT_CONFIGURE_has_libtoolize_2_4_or_newer=y
+CT_CONFIGURE_has_autoconf_2_63_or_newer=y
+CT_CONFIGURE_has_autoreconf_2_63_or_newer=y
+CT_CONFIGURE_has_gnu_m4_1_4_12_or_newer=y
+CT_CONFIGURE_has_git=y
+CT_MODULES=y
+
+#
+# Paths and misc options
+#
+
+#
+# crosstool-NG behavior
+#
+# CT_OBSOLETE is not set
+# CT_EXPERIMENTAL is not set
+# CT_DEBUG_CT is not set
+
+#
+# Paths
+#
+CT_LOCAL_TARBALLS_DIR="${HOME}/src"
+CT_SAVE_TARBALLS=y
+CT_WORK_DIR="${CT_TOP_DIR}/.build"
+CT_BUILD_TOP_DIR="${CT_WORK_DIR}/${CT_HOST:+HOST-${CT_HOST}/}${CT_TARGET}"
+CT_PREFIX_DIR="${CT_PREFIX:-${HOME}/x-tools}/${CT_HOST:+HOST-${CT_HOST}/}${CT_TARGET}"
+CT_RM_RF_PREFIX_DIR=y
+CT_REMOVE_DOCS=y
+CT_PREFIX_DIR_RO=y
+CT_STRIP_HOST_TOOLCHAIN_EXECUTABLES=y
+# CT_STRIP_TARGET_TOOLCHAIN_EXECUTABLES is not set
+
+#
+# Downloading
+#
+CT_DOWNLOAD_AGENT_WGET=y
+# CT_DOWNLOAD_AGENT_CURL is not set
+# CT_DOWNLOAD_AGENT_NONE is not set
+# CT_FORBID_DOWNLOAD is not set
+# CT_FORCE_DOWNLOAD is not set
+CT_CONNECT_TIMEOUT=10
+CT_DOWNLOAD_WGET_OPTIONS="--passive-ftp --tries=3 -nc --progress=dot:binary"
+# CT_ONLY_DOWNLOAD is not set
+# CT_USE_MIRROR is not set
+
+#
+# Extracting
+#
+# CT_FORCE_EXTRACT is not set
+CT_OVERRIDE_CONFIG_GUESS_SUB=y
+# CT_ONLY_EXTRACT is not set
+CT_PATCH_BUNDLED=y
+# CT_PATCH_LOCAL is not set
+# CT_PATCH_BUNDLED_LOCAL is not set
+# CT_PATCH_LOCAL_BUNDLED is not set
+# CT_PATCH_BUNDLED_FALLBACK_LOCAL is not set
+# CT_PATCH_LOCAL_FALLBACK_BUNDLED is not set
+# CT_PATCH_NONE is not set
+CT_PATCH_ORDER="bundled"
+
+#
+# Build behavior
+#
+CT_PARALLEL_JOBS=0
+CT_LOAD=""
+CT_USE_PIPES=y
+CT_EXTRA_CFLAGS_FOR_BUILD=""
+CT_EXTRA_LDFLAGS_FOR_BUILD=""
+CT_EXTRA_CFLAGS_FOR_HOST=""
+CT_EXTRA_LDFLAGS_FOR_HOST=""
+# CT_CONFIG_SHELL_SH is not set
+# CT_CONFIG_SHELL_ASH is not set
+CT_CONFIG_SHELL_BASH=y
+# CT_CONFIG_SHELL_CUSTOM is not set
+CT_CONFIG_SHELL="${bash}"
+
+#
+# Logging
+#
+# CT_LOG_ERROR is not set
+# CT_LOG_WARN is not set
+# CT_LOG_INFO is not set
+CT_LOG_EXTRA=y
+# CT_LOG_ALL is not set
+# CT_LOG_DEBUG is not set
+CT_LOG_LEVEL_MAX="EXTRA"
+# CT_LOG_SEE_TOOLS_WARN is not set
+CT_LOG_PROGRESS_BAR=y
+CT_LOG_TO_FILE=y
+CT_LOG_FILE_COMPRESS=y
+
+#
+# Target options
+#
+CT_ARCH="arm"
+# CT_ARCH_alpha is not set
+CT_ARCH_arm=y
+# CT_ARCH_avr is not set
+# CT_ARCH_m68k is not set
+# CT_ARCH_mips is not set
+# CT_ARCH_nios2 is not set
+# CT_ARCH_powerpc is not set
+# CT_ARCH_s390 is not set
+# CT_ARCH_sh is not set
+# CT_ARCH_sparc is not set
+# CT_ARCH_x86 is not set
+# CT_ARCH_xtensa is not set
+CT_ARCH_alpha_AVAILABLE=y
+CT_ARCH_arm_AVAILABLE=y
+CT_ARCH_avr_AVAILABLE=y
+CT_ARCH_m68k_AVAILABLE=y
+CT_ARCH_microblaze_AVAILABLE=y
+CT_ARCH_mips_AVAILABLE=y
+CT_ARCH_nios2_AVAILABLE=y
+CT_ARCH_powerpc_AVAILABLE=y
+CT_ARCH_s390_AVAILABLE=y
+CT_ARCH_sh_AVAILABLE=y
+CT_ARCH_sparc_AVAILABLE=y
+CT_ARCH_x86_AVAILABLE=y
+CT_ARCH_xtensa_AVAILABLE=y
+CT_ARCH_SUFFIX=""
+
+#
+# Generic target options
+#
+# CT_MULTILIB is not set
+CT_DEMULTILIB=y
+CT_ARCH_SUPPORTS_BOTH_MMU=y
+CT_ARCH_DEFAULT_HAS_MMU=y
+CT_ARCH_USE_MMU=y
+CT_ARCH_SUPPORTS_BOTH_ENDIAN=y
+CT_ARCH_DEFAULT_LE=y
+# CT_ARCH_BE is not set
+CT_ARCH_LE=y
+CT_ARCH_ENDIAN="little"
+CT_ARCH_SUPPORTS_32=y
+CT_ARCH_SUPPORTS_64=y
+CT_ARCH_DEFAULT_32=y
+CT_ARCH_BITNESS=64
+# CT_ARCH_32 is not set
+CT_ARCH_64=y
+
+#
+# Target optimisations
+#
+CT_ARCH_SUPPORTS_WITH_ARCH=y
+CT_ARCH_SUPPORTS_WITH_CPU=y
+CT_ARCH_SUPPORTS_WITH_TUNE=y
+CT_ARCH_EXCLUSIVE_WITH_CPU=y
+CT_ARCH_ARCH=""
+CT_ARCH_CPU=""
+CT_ARCH_TUNE=""
+CT_TARGET_CFLAGS=""
+CT_TARGET_LDFLAGS=""
+CT_ARCH_FLOAT=""
+
+#
+# arm other options
+#
+CT_ARCH_ARM_MODE="arm"
+CT_ARCH_ARM_MODE_ARM=y
+# CT_ARCH_ARM_MODE_THUMB is not set
+# CT_ARCH_ARM_INTERWORKING is not set
+CT_ARCH_ARM_EABI_FORCE=y
+CT_ARCH_ARM_EABI=y
+
+#
+# Toolchain options
+#
+
+#
+# General toolchain options
+#
+CT_FORCE_SYSROOT=y
+CT_USE_SYSROOT=y
+CT_SYSROOT_NAME="sysroot"
+CT_SYSROOT_DIR_PREFIX=""
+CT_WANTS_STATIC_LINK=y
+CT_WANTS_STATIC_LINK_CXX=y
+# CT_STATIC_TOOLCHAIN is not set
+CT_TOOLCHAIN_PKGVERSION=""
+CT_TOOLCHAIN_BUGURL=""
+
+#
+# Tuple completion and aliasing
+#
+CT_TARGET_VENDOR=""
+CT_TARGET_ALIAS_SED_EXPR=""
+CT_TARGET_ALIAS=""
+
+#
+# Toolchain type
+#
+CT_CROSS=y
+# CT_CANADIAN is not set
+CT_TOOLCHAIN_TYPE="cross"
+
+#
+# Build system
+#
+CT_BUILD=""
+CT_BUILD_PREFIX=""
+CT_BUILD_SUFFIX=""
+
+#
+# Misc options
+#
+# CT_TOOLCHAIN_ENABLE_NLS is not set
+
+#
+# Operating System
+#
+CT_KERNEL_SUPPORTS_SHARED_LIBS=y
+CT_KERNEL="linux"
+CT_KERNEL_VERSION="4.10.8"
+# CT_KERNEL_bare_metal is not set
+CT_KERNEL_linux=y
+CT_KERNEL_bare_metal_AVAILABLE=y
+CT_KERNEL_linux_AVAILABLE=y
+# CT_KERNEL_LINUX_CUSTOM is not set
+CT_KERNEL_V_4_10=y
+# CT_KERNEL_V_4_9 is not set
+# CT_KERNEL_V_4_4 is not set
+# CT_KERNEL_V_4_1 is not set
+# CT_KERNEL_V_3_16 is not set
+# CT_KERNEL_V_3_12 is not set
+# CT_KERNEL_V_3_10 is not set
+# CT_KERNEL_V_3_4 is not set
+# CT_KERNEL_V_3_2 is not set
+CT_KERNEL_windows_AVAILABLE=y
+
+#
+# Common kernel options
+#
+CT_SHARED_LIBS=y
+
+#
+# linux other options
+#
+CT_KERNEL_LINUX_VERBOSITY_0=y
+# CT_KERNEL_LINUX_VERBOSITY_1 is not set
+# CT_KERNEL_LINUX_VERBOSITY_2 is not set
+CT_KERNEL_LINUX_VERBOSE_LEVEL=0
+CT_KERNEL_LINUX_INSTALL_CHECK=y
+
+#
+# Binary utilities
+#
+CT_ARCH_BINFMT_ELF=y
+CT_BINUTILS="binutils"
+CT_BINUTILS_binutils=y
+
+#
+# GNU binutils
+#
+CT_BINUTILS_VERSION="2.28"
+# CT_BINUTILS_SHOW_LINARO is not set
+CT_BINUTILS_V_2_28=y
+# CT_BINUTILS_V_2_27 is not set
+# CT_BINUTILS_V_2_26 is not set
+CT_BINUTILS_2_27_or_later=y
+CT_BINUTILS_2_26_or_later=y
+CT_BINUTILS_2_25_1_or_later=y
+CT_BINUTILS_2_25_or_later=y
+CT_BINUTILS_2_24_or_later=y
+CT_BINUTILS_2_23_2_or_later=y
+CT_BINUTILS_HAS_HASH_STYLE=y
+CT_BINUTILS_HAS_GOLD=y
+CT_BINUTILS_GOLD_SUPPORTS_ARCH=y
+CT_BINUTILS_GOLD_SUPPORT=y
+CT_BINUTILS_HAS_PLUGINS=y
+CT_BINUTILS_HAS_PKGVERSION_BUGURL=y
+CT_BINUTILS_FORCE_LD_BFD_DEFAULT=y
+# CT_BINUTILS_LINKER_LD is not set
+CT_BINUTILS_LINKER_LD_GOLD=y
+# CT_BINUTILS_LINKER_GOLD_LD is not set
+CT_BINUTILS_GOLD_INSTALLED=y
+CT_BINUTILS_GOLD_THREADS=y
+CT_BINUTILS_LINKER_BOTH=y
+CT_BINUTILS_LINKERS_LIST="ld,gold"
+CT_BINUTILS_LD_WRAPPER=y
+CT_BINUTILS_LINKER_DEFAULT="bfd"
+CT_BINUTILS_PLUGINS=y
+CT_BINUTILS_EXTRA_CONFIG_ARRAY=""
+# CT_BINUTILS_FOR_TARGET is not set
+
+#
+# binutils other options
+#
+
+#
+# C-library
+#
+CT_LIBC="glibc"
+CT_LIBC_VERSION="2.25"
+CT_LIBC_glibc=y
+# CT_LIBC_uClibc is not set
+CT_LIBC_avr_libc_AVAILABLE=y
+CT_LIBC_glibc_AVAILABLE=y
+CT_THREADS="nptl"
+CT_CC_GLIBC_SHOW_LINARO=y
+# CT_LIBC_GLIBC_V_2_25 is not set
+# CT_LIBC_GLIBC_V_2_24 is not set
+# CT_LIBC_GLIBC_V_2_23 is not set
+CT_LIBC_GLIBC_2_23_or_later=y
+CT_LIBC_GLIBC_2_20_or_later=y
+CT_LIBC_GLIBC_2_17_or_later=y
+CT_LIBC_mingw_AVAILABLE=y
+CT_LIBC_musl_AVAILABLE=y
+CT_LIBC_newlib_AVAILABLE=y
+CT_LIBC_none_AVAILABLE=y
+CT_LIBC_uClibc_AVAILABLE=y
+CT_LIBC_SUPPORT_THREADS_ANY=y
+CT_LIBC_SUPPORT_THREADS_NATIVE=y
+
+#
+# Common C library options
+#
+CT_THREADS_NATIVE=y
+# CT_CREATE_LDSO_CONF is not set
+CT_LIBC_XLDD=y
+
+#
+# glibc other options
+#
+CT_LIBC_GLIBC_NEEDS_PORTS=y
+CT_LIBC_glibc_family=y
+CT_LIBC_GLIBC_EXTRA_CONFIG_ARRAY=""
+CT_LIBC_GLIBC_CONFIGPARMS=""
+CT_LIBC_GLIBC_EXTRA_CFLAGS=""
+# CT_LIBC_DISABLE_VERSIONING is not set
+CT_LIBC_OLDEST_ABI=""
+CT_LIBC_GLIBC_FORCE_UNWIND=y
+CT_LIBC_ADDONS_LIST=""
+# CT_LIBC_LOCALES is not set
+# CT_LIBC_GLIBC_KERNEL_VERSION_NONE is not set
+CT_LIBC_GLIBC_KERNEL_VERSION_AS_HEADERS=y
+# CT_LIBC_GLIBC_KERNEL_VERSION_CHOSEN is not set
+CT_LIBC_GLIBC_MIN_KERNEL="4.10.8"
+
+#
+# C compiler
+#
+CT_CC="gcc"
+CT_CC_CORE_PASSES_NEEDED=y
+CT_CC_CORE_PASS_1_NEEDED=y
+CT_CC_CORE_PASS_2_NEEDED=y
+CT_CC_gcc=y
+CT_CC_GCC_VERSION="4.9.4"
+# CT_CC_GCC_SHOW_LINARO is not set
+CT_CC_GCC_V_4_9_4=y
+# CT_CC_GCC_V_5_4_0 is not set
+# CT_CC_GCC_V_4_9_4 is not set
+CT_CC_GCC_4_8_or_later=y
+CT_CC_GCC_4_9_or_later=y
+CT_CC_GCC_4_or_later=y
+CT_CC_GCC_4=y
+# CT_CC_GCC_6_or_later=y
+CT_CC_GCC_ENABLE_PLUGINS=y
+CT_CC_GCC_GOLD=y
+CT_CC_GCC_ENABLE_CXX_FLAGS="-I/usr/include -fpermissive"
+CT_CC_GCC_CORE_EXTRA_CONFIG_ARRAY=""
+CT_CC_GCC_EXTRA_CONFIG_ARRAY=""
+CT_CC_GCC_STATIC_LIBSTDCXX=y
+# CT_CC_GCC_SYSTEM_ZLIB is not set
+CT_CC_GCC_CONFIG_TLS=m
+
+#
+# Optimisation features
+#
+CT_CC_GCC_USE_GRAPHITE=y
+CT_CC_GCC_USE_LTO=y
+
+#
+# Settings for libraries running on target
+#
+CT_CC_GCC_ENABLE_TARGET_OPTSPACE=y
+# CT_CC_GCC_LIBMUDFLAP is not set
+CT_CC_GCC_LIBGOMP=y
+# CT_CC_GCC_LIBSSP is not set
+# CT_CC_GCC_LIBQUADMATH is not set
+# CT_CC_GCC_LIBSANITIZER is not set
+
+#
+# Misc. obscure options.
+#
+CT_CC_CXA_ATEXIT=y
+# CT_CC_GCC_DISABLE_PCH is not set
+CT_CC_GCC_SJLJ_EXCEPTIONS=m
+CT_CC_GCC_LDBL_128=m
+# CT_CC_GCC_BUILD_ID is not set
+CT_CC_GCC_LNK_HASH_STYLE_DEFAULT=y
+# CT_CC_GCC_LNK_HASH_STYLE_SYSV is not set
+# CT_CC_GCC_LNK_HASH_STYLE_GNU is not set
+# CT_CC_GCC_LNK_HASH_STYLE_BOTH is not set
+CT_CC_GCC_LNK_HASH_STYLE=""
+CT_CC_GCC_DEC_FLOAT_AUTO=y
+# CT_CC_GCC_DEC_FLOAT_BID is not set
+# CT_CC_GCC_DEC_FLOAT_DPD is not set
+# CT_CC_GCC_DEC_FLOATS_NO is not set
+CT_CC_SUPPORT_CXX=y
+CT_CC_SUPPORT_FORTRAN=y
+CT_CC_SUPPORT_JAVA=y
+CT_CC_SUPPORT_ADA=y
+CT_CC_SUPPORT_OBJC=y
+CT_CC_SUPPORT_OBJCXX=y
+CT_CC_SUPPORT_GOLANG=y
+
+#
+# Additional supported languages:
+#
+CT_CC_LANG_CXX=y
+CT_CC_LANG_FORTRAN=y
+# CT_CC_LANG_JAVA is not set
+
+#
+# Debug facilities
+#
+# CT_DEBUG_duma is not set
+CT_DEBUG_gdb=y
+CT_GDB_CROSS=y
+# CT_GDB_CROSS_STATIC is not set
+# CT_GDB_CROSS_SIM is not set
+CT_GDB_CROSS_PYTHON=y
+CT_GDB_CROSS_PYTHON_BINARY=""
+CT_GDB_CROSS_EXTRA_CONFIG_ARRAY=""
+# CT_GDB_NATIVE is not set
+CT_GDB_GDBSERVER=y
+CT_GDB_GDBSERVER_HAS_IPA_LIB=y
+# CT_GDB_GDBSERVER_BUILD_IPA_LIB is not set
+
+#
+# gdb version
+#
+CT_GDB_VERSION="7.12.1"
+# CT_GDB_V_7_12_1 is not set
+# CT_GDB_V_7_11_1 is not set
+CT_GDB_7_12_or_later=y
+CT_GDB_7_2_or_later=y
+CT_GDB_7_0_or_later=y
+CT_GDB_HAS_PKGVERSION_BUGURL=y
+CT_GDB_HAS_PYTHON=y
+CT_GDB_INSTALL_GDBINIT=y
+# CT_DEBUG_ltrace is not set
+# CT_DEBUG_strace is not set
+
+#
+# Companion libraries
+#
+CT_COMPLIBS_NEEDED=y
+CT_LIBICONV_NEEDED=y
+CT_GETTEXT_NEEDED=y
+CT_GMP_NEEDED=y
+CT_MPFR_NEEDED=y
+CT_ISL_NEEDED=y
+CT_CLOOG_NEEDED=y
+CT_MPC_NEEDED=y
+# CT_EXPAT_NEEDED=y
+CT_NCURSES_NEEDED=y
+CT_COMPLIBS=y
+CT_LIBICONV=y
+CT_GETTEXT=y
+CT_GMP=y
+CT_MPFR=y
+CT_ISL=y
+CT_CLOOG=y
+CT_MPC=y
+# CT_EXPAT=y
+CT_NCURSES=y
+# CT_ZLIB is not set
+CT_LIBICONV_V_1_15=y
+# CT_LIBICONV_V_1_14 is not set
+CT_LIBICONV_VERSION="1.15"
+CT_GETTEXT_V_0_19_8_1=y
+CT_GETTEXT_VERSION="0.19.8.1"
+CT_GMP_V_6_1_2=y
+CT_GMP_5_0_2_or_later=y
+CT_GMP_VERSION="6.1.2"
+CT_MPFR_V_3_1_5=y
+CT_MPFR_VERSION="3.1.5"
+CT_ISL_V_0_15=y
+CT_ISL_V_0_15_or_later=y
+CT_ISL_V_0_14_or_later=y
+CT_ISL_V_0_12_or_later=y
+CT_ISL_VERSION="0.15"
+CT_CLOOG_V_0_18_4=y
+CT_CLOOG_VERSION="0.18.4"
+CT_CLOOG_0_18_4_or_later=y
+CT_CLOOG_0_18_or_later=y
+CT_MPC_V_1_0_3=y
+CT_MPC_VERSION="1.0.3"
+# CT_EXPAT_V_2_2_0=y
+# CT_EXPAT_VERSION="2.2.0"
+CT_NCURSES_V_6_0=y
+CT_NCURSES_VERSION="6.0"
+CT_NCURSES_HOST_CONFIG_ARGS=""
+CT_NCURSES_HOST_DISABLE_DB=y
+CT_NCURSES_HOST_FALLBACKS="linux,xterm,xterm-color,xterm-256color,vt100"
+CT_NCURSES_TARGET_CONFIG_ARGS=""
+# CT_NCURSES_TARGET_DISABLE_DB is not set
+CT_NCURSES_TARGET_FALLBACKS=""
+
+#
+# Companion libraries common options
+#
+# CT_COMPLIBS_CHECK is not set
+
+#
+# Companion tools
+#
+# CT_COMP_TOOLS_FOR_HOST is not set
+# CT_COMP_TOOLS_autoconf is not set
+CT_COMP_TOOLS_automake=y
+CT_AUTOMAKE_V_1_15=y
+CT_AUTOMAKE_VERSION="1.15"
+CT_COMP_TOOLS_libtool=y
+CT_LIBTOOL_V_2_4_6=y
+CT_LIBTOOL_VERSION="2.4.6"
+# CT_COMP_TOOLS_m4 is not set
+# CT_COMP_TOOLS_make is not set


### PR DESCRIPTION
Resolves #367.

Add support for manylinux2014-aarch64:
 - Added Dockerfile, Toolchain, and crosstool config (Referred linux-arm64 wherever requried).
 - Using FROM dockcross/manylinux2014-x64 image.
 - Updated Makefile.
 - To build manylinux2014-aarch64 locally just use 'make manylinux2014-aarch64'.
 - Run test is successful. Used 'make manylinux2014-aarch64.test.
 - Also added manylinux2014-aarch64 in circleCI config file referring manylinux2014-x64.