### PR TITLE
if PWD is a symbolic link then read / find the link

### DIFF
--- a/imagefiles/dockcross
+++ b/imagefiles/dockcross
@@ -200,6 +200,7 @@ elif [ -n "$MSYS" ]; then
     HOST_PWD=${HOST_PWD/\//:\/}
 else
     HOST_PWD=$PWD
+    [ -L $HOST_PWD ] && HOST_PWD=$(readlink $HOST_PWD)
 fi
 
 # Mount Additional Volumes


### PR DESCRIPTION
so `docker` mounts the volume properly.

Looks like https://github.com/dockcross/dockcross/issues/186 / https://github.com/dockcross/dockcross/pull/189 addressed the issue for Docker on Windows.

This issue still exists for `MSYS`... Unfortunately, I don't have a Windows machine (right now) to work on a fix...