### PR TITLE
manylinux2014-aarch64: Set AUDITWHEEL_ARCH and AUDITWHEEL_PLAT variables

### DIFF
--- a/manylinux2014-aarch64/Dockerfile.in
+++ b/manylinux2014-aarch64/Dockerfile.in
@@ -41,6 +41,9 @@ ENV PATH ${PATH}:${CROSS_ROOT}/bin
 ENV CROSS_COMPILE ${CROSS_TRIPLE}-
 ENV ARCH arm64
 
+ENV AUDITWHEEL_ARCH aarch64
+ENV AUDITWHEEL_PLAT manylinux2014_$AUDITWHEEL_ARCH
+
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
 ARG IMAGE=dockcross/manylinux2014-aarch64


### PR DESCRIPTION
This commit overrides variables inherited from the base image.