### PR TITLE
manylinux.crosstool: Fix use of sudo removing sudo provided by devtoolset

### DIFF
--- a/common-manylinux.crosstool
+++ b/common-manylinux.crosstool
@@ -57,7 +57,10 @@ RUN \
   /dockcross/install-crosstool-ng-toolchain.sh \
   -p "${XCC_PREFIX}" \
   -c /dockcross/crosstool-ng.config && \
-  rm -rf /dockcross/crosstool /dockcross/install-crosstool-ng-toolchain.sh
+  rm -rf /dockcross/crosstool /dockcross/install-crosstool-ng-toolchain.sh && \
+  # Remove sudo provided by devtoolset since it doesn't work with
+  # our sudo wrapper calling gosu.
+  rm -f /opt/rh/devtoolset-9/root/usr/bin/sudo
 
 # Restore our default workdir (from "dockcross/base").
 WORKDIR /work

--- a/common.manylinux
+++ b/common.manylinux
@@ -20,7 +20,7 @@ RUN \
   yum clean all && \
   /buildscripts/install-gosu-binary.sh && \
   /buildscripts/install-gosu-binary-wrapper.sh && \
-  # Remove sudo provided by "devtoolset-2" and "devtoolset-8" since it doesn't work with
+  # Remove sudo provided by devtoolset since it doesn't work with
   # our sudo wrapper calling gosu.
   rm -f /opt/rh/devtoolset-2/root/usr/bin/sudo && \
   rm -f /opt/rh/devtoolset-7/root/usr/bin/sudo && \


### PR DESCRIPTION
This commit removes sudo provided by devtoolset since it doesn't work with
our sudo wrapper calling gosu.

It fixes error like the following:
```
  /opt/rh/devtoolset-9/root/usr/bin/sudo: line 41: /usr/bin/sudo: No such file or directory
```
Adapted from e513a26 (manylinux: Remove rh devtoolset sudo)

Co-authored-by: odidev <odidev@puresoftware.com>