### PR TITLE
Split "dockcross" script and it's dependencies to separate include

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -3,6 +3,8 @@ MAINTAINER Matt McCormick "matt.mccormick@kitware.com"
 
 #include "common.debian"
 
+#include "common.dockcross"
+
 #include "common.docker"
 
 # Build-time metadata as defined at http://label-schema.org

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ GEN_IMAGE_DOCKERFILES = $(addsuffix /Dockerfile,$(GEN_IMAGES))
 # These images are expected to have explicit rules for *both* build and testing
 NON_STANDARD_IMAGES = web-wasm manylinux1-x64 manylinux1-x86 manylinux2010-x64 manylinux2010-x86 manylinux2014-x64 manylinux2014-aarch64
 
-DOCKER_COMPOSITE_SOURCES = common.docker common.debian common.manylinux common.crosstool common.windows common-manylinux.crosstool
+DOCKER_COMPOSITE_SOURCES = common.docker common.debian common.manylinux common.crosstool common.windows common-manylinux.crosstool common.dockcross
 
 # This list all available images
 IMAGES = $(STANDARD_IMAGES) $(NON_STANDARD_IMAGES)
@@ -68,6 +68,7 @@ $(GEN_IMAGE_DOCKERFILES) Dockerfile: %Dockerfile: %Dockerfile.in $(DOCKER_COMPOS
 		-e '/common.crosstool/ r common.crosstool' \
 		-e '/common-manylinux.crosstool/ r common-manylinux.crosstool' \
 		-e '/common.windows/ r common.windows' \
+		-e '/common.dockcross/ r common.dockcross' \
 		$< > $@
 
 #

--- a/common.debian
+++ b/common.debian
@@ -1,9 +1,3 @@
-# Image build scripts
-COPY \
-  imagefiles/install-gosu-binary.sh \
-  imagefiles/install-gosu-binary-wrapper.sh \
-  /buildscripts/
-
 ARG DEBIAN_FRONTEND=noninteractive
 ARG REPO=http://cdn-fastly.deb.debian.org
 
@@ -48,7 +42,4 @@ RUN \
     zip \
     zlib1g-dev \
   && \
-  apt-get clean --yes && \
-  /buildscripts/install-gosu-binary.sh && \
-  /buildscripts/install-gosu-binary-wrapper.sh && \
-  rm -rf /buildscripts
+  apt-get clean --yes

--- a/common.dockcross
+++ b/common.dockcross
@@ -7,20 +7,10 @@ COPY \
   /buildscripts/
 
 RUN \
-  apt-get update --yes && \
-  apt-get install --no-install-recommends --yes \
-    ca-certificates \
-    curl \
-    dirmngr \
-    gpg \
-  && \
-  apt-get clean --yes && \
+  set -x && \
   /buildscripts/install-gosu-binary.sh && \
   /buildscripts/install-gosu-binary-wrapper.sh && \
   rm -rf /buildscripts
 
 # Runtime scripts
 COPY imagefiles/entrypoint.sh imagefiles/dockcross /dockcross/
-
-WORKDIR /work
-ENTRYPOINT ["/dockcross/entrypoint.sh"]

--- a/common.dockcross
+++ b/common.dockcross
@@ -19,9 +19,8 @@ RUN \
   /buildscripts/install-gosu-binary-wrapper.sh && \
   rm -rf /buildscripts
 
-RUN echo "root:root" | chpasswd
-WORKDIR /work
-ENTRYPOINT ["/dockcross/entrypoint.sh"]
-
 # Runtime scripts
 COPY imagefiles/entrypoint.sh imagefiles/dockcross /dockcross/
+
+WORKDIR /work
+ENTRYPOINT ["/dockcross/entrypoint.sh"]

--- a/common.dockcross
+++ b/common.dockcross
@@ -9,6 +9,7 @@ COPY \
 RUN \
   apt-get update --yes && \
   apt-get install --no-install-recommends --yes \
+    ca-certificates \
     curl \
     dirmngr \
     gpg \

--- a/common.dockcross
+++ b/common.dockcross
@@ -1,0 +1,26 @@
+WORKDIR /usr/src
+
+# Image build scripts
+COPY \
+  imagefiles/install-gosu-binary.sh \
+  imagefiles/install-gosu-binary-wrapper.sh \
+  /buildscripts/
+
+RUN \
+  apt-get update --yes && \
+  apt-get install --no-install-recommends --yes \
+    curl \
+    dirmngr \
+    gpg \
+  && \
+  apt-get clean --yes && \
+  /buildscripts/install-gosu-binary.sh && \
+  /buildscripts/install-gosu-binary-wrapper.sh && \
+  rm -rf /buildscripts
+
+RUN echo "root:root" | chpasswd
+WORKDIR /work
+ENTRYPOINT ["/dockcross/entrypoint.sh"]
+
+# Runtime scripts
+COPY imagefiles/entrypoint.sh imagefiles/dockcross /dockcross/

--- a/common.docker
+++ b/common.docker
@@ -37,4 +37,3 @@ ENTRYPOINT ["/dockcross/entrypoint.sh"]
 # Runtime scripts
 COPY imagefiles/cmake.sh /usr/local/bin/cmake
 COPY imagefiles/ccmake.sh /usr/local/bin/ccmake
-COPY imagefiles/entrypoint.sh imagefiles/dockcross /dockcross/

--- a/common.manylinux
+++ b/common.manylinux
@@ -1,7 +1,5 @@
 # Image build scripts
 COPY \
-  imagefiles/install-gosu-binary.sh \
-  imagefiles/install-gosu-binary-wrapper.sh \
   manylinux-common/install-python-packages.sh \
   /buildscripts/
 
@@ -18,8 +16,6 @@ RUN \
     zip \
   && \
   yum clean all && \
-  /buildscripts/install-gosu-binary.sh && \
-  /buildscripts/install-gosu-binary-wrapper.sh && \
   # Remove sudo provided by devtoolset since it doesn't work with
   # our sudo wrapper calling gosu.
   rm -f /opt/rh/devtoolset-2/root/usr/bin/sudo && \

--- a/manylinux1-x64/Dockerfile.in
+++ b/manylinux1-x64/Dockerfile.in
@@ -5,6 +5,8 @@ ENV DEFAULT_DOCKCROSS_IMAGE dockcross/manylinux1-x64
 
 #include "common.manylinux"
 
+#include "common.dockcross"
+
 #include "common.docker"
 
 ENV CROSS_TRIPLE x86_64-linux-gnu

--- a/manylinux1-x86/Dockerfile.in
+++ b/manylinux1-x86/Dockerfile.in
@@ -5,6 +5,8 @@ ENV DEFAULT_DOCKCROSS_IMAGE dockcross/manylinux1-x86
 
 #include "common.manylinux"
 
+#include "common.dockcross"
+
 #include "common.docker"
 
 ENV CROSS_TRIPLE i686-linux-gnu

--- a/manylinux2010-x64/Dockerfile.in
+++ b/manylinux2010-x64/Dockerfile.in
@@ -5,6 +5,8 @@ ENV DEFAULT_DOCKCROSS_IMAGE dockcross/manylinux2010-x64
 
 #include "common.manylinux"
 
+#include "common.dockcross"
+
 #include "common.docker"
 
 # Override yum to work around the problem with newly built libcurl.so.4

--- a/manylinux2010-x86/Dockerfile.in
+++ b/manylinux2010-x86/Dockerfile.in
@@ -5,6 +5,8 @@ ENV DEFAULT_DOCKCROSS_IMAGE dockcross/manylinux2010-x86
 
 #include "common.manylinux"
 
+#include "common.dockcross"
+
 #include "common.docker"
 
 # Override yum to work around the problem with newly built libcurl.so.4

--- a/manylinux2014-x64/Dockerfile.in
+++ b/manylinux2014-x64/Dockerfile.in
@@ -6,6 +6,8 @@ ENV DEFAULT_DOCKCROSS_IMAGE dockcross/manylinux2014-x64
 
 #include "common.manylinux"
 
+#include "common.dockcross"
+
 #include "common.docker"
 
 # Override yum to work around the problem with newly built libcurl.so.4

--- a/web-wasm/Dockerfile.in
+++ b/web-wasm/Dockerfile.in
@@ -5,8 +5,6 @@ MAINTAINER Matt McCormick "matt.mccormick@kitware.com"
 # See https://github.com/asRIA/emscripten-docker/blob/master/Dockerfile.in#L4
 RUN rm /bin/sh && ln -s /bin/dash /bin/sh
 
-COPY imagefiles/install-gosu-binary-wrapper.sh /buildscripts/
-
 ARG DEBIAN_FRONTEND=noninteractive
 ARG REPO=http://cdn-fastly.deb.debian.org
 
@@ -51,9 +49,9 @@ RUN \
     xz-utils \
     zlib1g-dev \
   && \
-  apt-get clean --yes && \
-  /buildscripts/install-gosu-binary-wrapper.sh && \
-  rm -rf /buildscripts
+  apt-get clean --yes
+
+#include "common.dockcross"
 
 #include "common.docker"
 


### PR DESCRIPTION

Closes #423 

NOTE: This is slightly different than what is mentioned in the issue.

1. This makes an attempt to utilize the "common.dockcross" by the other dockerfiles
2. This does not include apt-get's to install dependencies because they are incompatible with the existing common.debian (and certainly with the manylinux image).