### PR TITLE
Better sudo script

### DIFF
--- a/imagefiles/install-gosu-binary-wrapper.sh
+++ b/imagefiles/install-gosu-binary-wrapper.sh
@@ -13,13 +13,44 @@ gosu nobody true
 
 # To ensure that our custom sudo wrapper is not
 # overwritten by a future re-install of sudo, it
-# is created in /usr/loca/bin
+# is created in /usr/local/bin
 
 cat << EOF >> /usr/local/bin/sudo
 #!/bin/sh
 # Emulate the sudo command
-exec gosu root:root "\$@"
+SUDO_USER=root
+SUDO_GROUP=root
+while (( "\$#" )); do
+  case "\$1" in
+    # user option
+    -u)
+      SUDO_USER=\$2
+      shift 2
+      ;;
+    # group option
+    -g)
+      SUDO_GROUP=\$2
+      shift 2
+      ;;
+    # skipping arguments without values
+    -A|-b|-E|-e|-H|-h|-K|-n|-P|-S|-V|-v)
+      shift 1
+      ;;
+    # skipping arguments with values
+    -a|-C|-c|-D|-i|-k|-l|-ll|-p|-r|-s|-t|-U)
+      shift 2
+      ;;
+    # stop processing command line arguments
+    --)
+      shift 1
+      break
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+exec gosu \$SUDO_USER:\$SUDO_GROUP "\$@"
 EOF
 
 chmod +x /usr/local/bin/sudo
-


### PR DESCRIPTION
Make the custom sudo script based on gosu closer to the real sudo by supporting user and group and ignoring unsupported arguments, which is helpful to handle the case of `sudo -p message` frictionlessly.