### PR TITLE
Added manylinux2014-x86

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -405,6 +405,26 @@ jobs:
       - save_cache:
           key: manylinux2014-x64-assets-{{ .Revision }}
           paths: ~/docker/manylinux2014-x64.tar
+  manylinux2014-x86:
+    <<: *build-settings
+    steps:
+      - restore_cache:
+          key: base-assets-{{ .Revision }}
+      - run:
+         name: manylinux2014-x86 build
+         no_output_timeout: 1.5h
+         command: |
+           docker load -i ~/docker/base.tar
+           make manylinux2014-x86
+           tagged=$(docker images -q -f 'since=dockcross/manylinux2014-x86:latest' --format '{{.Repository}}:{{.Tag}}' | grep manylinux2014-x86)
+           docker save -o ~/docker/manylinux2014-x86.tar dockcross/manylinux2014-x86:latest $tagged
+      - run:
+         name: manylinux2014-x86 test
+         command: |
+           make manylinux2014-x86.test
+      - save_cache:
+          key: manylinux2014-x86-assets-{{ .Revision }}
+          paths: ~/docker/manylinux2014-x86.tar
   manylinux2014-aarch64:
     <<: *build-settings
     steps:
@@ -776,7 +796,17 @@ jobs:
               docker push $tagged
             fi
       - restore_cache:
-          key: manylinux2014-x64-assets-{{ .Revision }}
+          key: manylinux2014-x86-assets-{{ .Revision }}
+      - deploy:
+          name: Deploy manylinux2014-x86
+          command: |
+            docker load -i ~/docker/manylinux2014-x86.tar
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              docker login -u $DOCKER_USER -p $DOCKER_PASS
+              docker push dockcross/manylinux2014-x86:latest
+              tagged=$(docker images -q -f 'since=dockcross/manylinux2014-x86:latest' --format '{{.Repository}}:{{.Tag}}' | grep manylinux2014-x86)
+              docker push $tagged
+            fi
       - restore_cache:
           key: manylinux2014-aarch64-assets-{{ .Revision }}
       - deploy:
@@ -923,6 +953,9 @@ workflows:
         - manylinux2014-x64:
             requires:
               - base
+        - manylinux2014-x86:
+            requires:
+              - base
         - manylinux2014-aarch64:
             requires:
               - base
@@ -966,6 +999,7 @@ workflows:
               - manylinux2010-x64
               - manylinux2010-x86
               - manylinux2014-x64
+              - manylinux2014-x86
               - manylinux2014-aarch64
               - windows-static-x64
               - windows-static-x64-posix

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@ BIN = ./bin
 STANDARD_IMAGES = linux-s390x android-arm android-arm64 linux-x86 linux-x64 linux-arm64 linux-armv5 linux-armv5-musl linux-armv6 linux-armv7 linux-armv7a linux-mips linux-mipsel linux-ppc64le windows-static-x86 windows-static-x64 windows-static-x64-posix windows-shared-x86 windows-shared-x64 windows-shared-x64-posix
 
 # Generated Dockerfiles.
-GEN_IMAGES = linux-s390x linux-mips manylinux1-x64 manylinux1-x86 manylinux2010-x64 manylinux2010-x86 manylinux2014-x64 manylinux2014-aarch64 web-wasm linux-arm64 windows-static-x86 windows-static-x64 windows-static-x64-posix windows-shared-x86 windows-shared-x64 windows-shared-x64-posix linux-armv7 linux-armv7a linux-armv5 linux-armv5-musl linux-ppc64le
+GEN_IMAGES = linux-s390x linux-mips manylinux1-x64 manylinux1-x86 manylinux2010-x64 manylinux2010-x86 manylinux2014-x64 manylinux2014-x86 manylinux2014-aarch64 web-wasm linux-arm64 windows-static-x86 windows-static-x64 windows-static-x64-posix windows-shared-x86 windows-shared-x64 windows-shared-x64-posix linux-armv7 linux-armv7a linux-armv5 linux-armv5-musl linux-ppc64le
 GEN_IMAGE_DOCKERFILES = $(addsuffix /Dockerfile,$(GEN_IMAGES))
 
 # These images are expected to have explicit rules for *both* build and testing
-NON_STANDARD_IMAGES = web-wasm manylinux1-x64 manylinux1-x86 manylinux2010-x64 manylinux2010-x86 manylinux2014-x64 manylinux2014-aarch64
+NON_STANDARD_IMAGES = web-wasm manylinux1-x64 manylinux1-x86 manylinux2010-x64 manylinux2010-x86 manylinux2014-x64 manylinux2014-x86 manylinux2014-aarch64
 
 DOCKER_COMPOSITE_SOURCES = common.docker common.debian common.manylinux common.crosstool common.windows common-manylinux.crosstool
 
@@ -145,6 +145,30 @@ manylinux2014-x64: manylinux2014-x64/Dockerfile
 manylinux2014-x64.test: manylinux2014-x64
 	$(DOCKER) run $(RM) dockcross/manylinux2014-x64 > $(BIN)/dockcross-manylinux2014-x64 && chmod +x $(BIN)/dockcross-manylinux2014-x64
 	$(BIN)/dockcross-manylinux2014-x64 /opt/python/cp35-cp35m/bin/python test/run.py
+
+#
+# manylinux2014-x86
+#
+manylinux2014-x86: manylinux2014-x86/Dockerfile
+	mkdir -p $@/imagefiles && cp -r imagefiles $@/
+	$(DOCKER) build -t $(ORG)/manylinux2014-x86:latest \
+		--build-arg IMAGE=$(ORG)/manylinux2014-x86 \
+		--build-arg VCS_REF=`git rev-parse --short HEAD` \
+		--build-arg VCS_URL=`git config --get remote.origin.url` \
+		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+		-f manylinux2014-x86/Dockerfile .
+	$(DOCKER) build -t $(ORG)/manylinux2014-x86:$(TAG) \
+		--build-arg IMAGE=$(ORG)/manylinux2014-x86 \
+		--build-arg VERSION=$(TAG) \
+		--build-arg VCS_REF=`git rev-parse --short HEAD` \
+		--build-arg VCS_URL=`git config --get remote.origin.url` \
+		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+		-f manylinux2014-x86/Dockerfile .
+	rm -rf $@/imagefiles
+
+manylinux2014-x86.test: manylinux2014-x86
+	$(DOCKER) run $(RM) dockcross/manylinux2014-x86 > $(BIN)/dockcross-manylinux2014-x86 && chmod +x $(BIN)/dockcross-manylinux2014-x86
+	$(BIN)/dockcross-manylinux2014-x86 /opt/python/cp35-cp35m/bin/python test/run.py
 
 #
 # manylinux2010-x64

--- a/README.rst
+++ b/README.rst
@@ -193,7 +193,15 @@ dockcross/linux-x86
   :target: https://microbadger.com/images/dockcross/manylinux2014-x64
 
 dockcross/manylinux2014-x64
-  |manylinux2014-x64-images| Docker `manylinux2014 <https://github.com/pypa/manylinux>`_ image for building Linux x86_64 / amd64 `Python wheel packages <http://pythonwheels.com/>`_. It includes Python 2.7, 3.4, 3.5, 3.6, 3.7 and 3.8.
+  |manylinux2014-x64-images| Docker `manylinux2014 <https://github.com/pypa/manylinux>`_ image for building Linux x86_64 / amd64 `Python wheel packages <http://pythonwheels.com/>`_. It includes Python 3.5, 3.6, 3.7, 3.8, and 3.9.
+  Also has support for the dockcross script, and it has installations of CMake, Ninja, and `scikit-build <http://scikit-build.org>`_. For CMake, it sets `MANYLINUX2014` to "TRUE" in the toolchain.
+
+
+.. |manylinux2014-x86-images| image:: https://images.microbadger.com/badges/image/dockcross/manylinux2014-x86.svg
+  :target: https://microbadger.com/images/dockcross/manylinux2014-x86
+
+dockcross/manylinux2014-x86
+  |manylinux2014-x86-images| Docker `manylinux2014 <https://github.com/pypa/manylinux>`_ image for building Linux i686 `Python wheel packages <http://pythonwheels.com/>`_. It includes Python 3.5, 3.6, 3.7, 3.8, and 3.9.
   Also has support for the dockcross script, and it has installations of CMake, Ninja, and `scikit-build <http://scikit-build.org>`_. For CMake, it sets `MANYLINUX2014` to "TRUE" in the toolchain.
 
 
@@ -201,7 +209,7 @@ dockcross/manylinux2014-x64
   :target: https://microbadger.com/images/dockcross/manylinux2014-aarch64
 
 dockcross/manylinux2014-aarch64
-  |manylinux2014-aarch64-images| Docker `manylinux2014 <https://github.com/pypa/manylinux>`_ image for building Linux aarch64 / arm64 `Python wheel packages <http://pythonwheels.com/>`_. It includes Python 2.7, 3.4, 3.5, 3.6, 3.7 and 3.8.
+  |manylinux2014-aarch64-images| Docker `manylinux2014 <https://github.com/pypa/manylinux>`_ image for building Linux aarch64 / arm64 `Python wheel packages <http://pythonwheels.com/>`_. It includes Python 3.5, 3.6, 3.7, 3.8, and 3.9.
   Also has support for the dockcross script, and it has installations of CMake, Ninja, and `scikit-build <http://scikit-build.org>`_. For CMake, it sets `MANYLINUX2014` to "TRUE" in the toolchain.
 
 

--- a/common.docker
+++ b/common.docker
@@ -18,7 +18,7 @@ COPY \
   /buildscripts/
 
 RUN \
-  X86_FLAG=$([ "$DEFAULT_DOCKCROSS_IMAGE" = "dockcross/manylinux1-x86" -o "$DEFAULT_DOCKCROSS_IMAGE" = "dockcross/manylinux2010-x86" ] && echo "-32" || echo "") && \
+  X86_FLAG=$([ "$DEFAULT_DOCKCROSS_IMAGE" = "dockcross/manylinux1-x86" -o "$DEFAULT_DOCKCROSS_IMAGE" = "dockcross/manylinux2010-x86" -o "$DEFAULT_DOCKCROSS_IMAGE" = "dockcross/manylinux2014-x86" ] && echo "-32" || echo "") && \
   /buildscripts/build-and-install-openssl.sh $X86_FLAG && \
   /buildscripts/build-and-install-openssh.sh && \
   /buildscripts/build-and-install-curl.sh && \

--- a/common.manylinux
+++ b/common.manylinux
@@ -8,7 +8,7 @@ COPY \
 RUN \
   set -x && \
   yum -y install \
-    epel-release \
+    $([ "$DEFAULT_DOCKCROSS_IMAGE" = "dockcross/manylinux2014-x86" ] && echo "" || echo "epel-release") \
     gpg \
     zlib-devel \
     gettext \
@@ -25,6 +25,7 @@ RUN \
   rm -f /opt/rh/devtoolset-2/root/usr/bin/sudo && \
   rm -f /opt/rh/devtoolset-7/root/usr/bin/sudo && \
   rm -f /opt/rh/devtoolset-8/root/usr/bin/sudo && \
+  rm -f /opt/rh/devtoolset-9/root/usr/bin/sudo && \
   /buildscripts/install-python-packages.sh && \
   rm -rf /buildscripts
 

--- a/manylinux2014-x86/Dockerfile.in
+++ b/manylinux2014-x86/Dockerfile.in
@@ -1,0 +1,46 @@
+# Recent versions address yum functionality
+FROM quay.io/pypa/manylinux2014_i686:latest
+MAINTAINER Matt McCormick "matt.mccormick@kitware.com"
+
+ENV DEFAULT_DOCKCROSS_IMAGE dockcross/manylinux2014-x86
+
+#include "common.manylinux"
+
+#include "common.docker"
+
+# Override yum to work around the problem with newly built libcurl.so.4
+# https://access.redhat.com/solutions/641093
+RUN echo $'#!/bin/bash\n\
+LD_PRELOAD=/usr/lib64/libcurl.so.4 /usr/bin/yum "$@"' > /usr/local/bin/yum && chmod a+x /usr/local/bin/yum
+
+ENV CROSS_TRIPLE i686-linux-gnu
+ENV CROSS_ROOT /opt/rh/devtoolset-9/root/usr/bin
+ENV AS=${CROSS_ROOT}/as \
+    AR=${CROSS_ROOT}/ar \
+    CC=${CROSS_ROOT}/gcc \
+    CPP=${CROSS_ROOT}/cpp \
+    CXX=${CROSS_ROOT}/g++ \
+    LD=${CROSS_ROOT}/ld \
+    FC=${CROSS_ROOT}/gfortran
+
+COPY linux-x86/${CROSS_TRIPLE}-noop.sh /usr/bin/${CROSS_TRIPLE}-noop
+
+COPY manylinux2014-x86/Toolchain.cmake ${CROSS_ROOT}/../lib/
+ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/../lib/Toolchain.cmake
+
+COPY linux-x86/linux32-entrypoint.sh /dockcross/
+ENTRYPOINT ["/dockcross/linux32-entrypoint.sh"]
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG IMAGE=dockcross/manylinux2014-x86
+ARG VERSION=latest
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.version=$VERSION \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"
+ENV DEFAULT_DOCKCROSS_IMAGE ${IMAGE}:${VERSION}

--- a/manylinux2014-x86/Toolchain.cmake
+++ b/manylinux2014-x86/Toolchain.cmake
@@ -1,0 +1,11 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_CROSSCOMPILING FALSE)
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR i686)
+
+set(MANYLINUX2014 TRUE)
+
+set(CMAKE_C_COMPILER /opt/rh/devtoolset-9/root/usr/bin/gcc)
+set(CMAKE_CXX_COMPILER /opt/rh/devtoolset-9/root/usr/bin/g++)
+set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
+set(CMAKE_Fortran_COMPILER /opt/rh/devtoolset-9/root/usr/bin/gfortran)


### PR DESCRIPTION
Added `manylinux2014-x86` based on `manylinux` with some modification:

- Skipping installing `epel-release` package only for `manylinux2014-x86` because EPEL stopped supporting x86 from CentOS 7.
- Adding `/opt/rh/devtoolset-9/root/usr/bin/sudo` to a list of files to be removed for gosu.
- Changing the description of `manylinux2014` to have Python 3.5 or later since it stopped supporting Python 2.7 and 3.4.
