### PR TITLE
web-wasm: Make emscripten cache writable by non-root

### DIFF
--- a/web-wasm/Dockerfile.in
+++ b/web-wasm/Dockerfile.in
@@ -62,6 +62,7 @@ ENV CC=/emsdk/upstream/emscripten/emcc \
   CXX=/emsdk/upstream/emscripten/em++ \
   AR=/emsdk/upstream/emscripten/emar
 
+RUN chmod -R 777 /emsdk/upstream/emscripten/cache
 
 ENV CMAKE_TOOLCHAIN_FILE /emsdk/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake
 


### PR DESCRIPTION
Prevents build failures.