### PR TITLE
Eagerly evaluate TAG, to ensure it's consistent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ ifeq ("$(CIRCLECI)", "true")
 endif
 
 # Tag images with date and Git short hash in addition to revision
-TAG = $(shell date '+%Y%m%d')-$(shell git rev-parse --short HEAD)
+TAG := $(shell date '+%Y%m%d')-$(shell git rev-parse --short HEAD)
 
 #
 # images: This target builds all IMAGES (because it is the first one, it is built by default)


### PR DESCRIPTION
By deferring the evaluation of `TAG`, we risk the date changing mid-build leading to images from the same `make` invocation having different tags. The date and commit hash from when the build was _started_ are now used throughout.