### PR TITLE
Add linux-arm64-musl image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,26 @@ jobs:
       - save_cache:
           key: linux-arm64-assets-{{ .Revision }}
           paths: ~/docker/linux-arm64.tar
+  linux-arm64-musl:
+    <<: *build-settings
+    steps:
+      - restore_cache:
+          key: base-assets-{{ .Revision }}
+      - run:
+         name: linux-arm64-musl build
+         no_output_timeout: 1.5h
+         command: |
+           docker load -i ~/docker/base.tar
+           make linux-arm64-musl
+           tagged=$(docker images -q -f 'since=dockcross/linux-arm64-musl:latest' --format '{{.Repository}}:{{.Tag}}' | grep linux-arm64-musl)
+           docker save -o ~/docker/linux-arm64-musl.tar dockcross/linux-arm64-musl:latest $tagged
+      - run:
+         name: linux-arm64-musl test
+         command: |
+           make linux-arm64-musl.test
+      - save_cache:
+          key: linux-arm64-musl-assets-{{ .Revision }}
+          paths: ~/docker/linux-arm64-musl.tar
   linux-armv5:
     <<: *build-settings
     steps:
@@ -627,6 +647,18 @@ jobs:
               docker push $tagged
             fi
       - restore_cache:
+          key: linux-arm64-musl-assets-{{ .Revision }}
+      - deploy:
+          name: Deploy linux-arm64-musl
+          command: |
+            docker load -i ~/docker/linux-arm64-musl.tar
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              docker login -u $DOCKER_USER -p $DOCKER_PASS
+              docker push dockcross/linux-arm64-musl:latest
+              tagged=$(docker images -q -f 'since=dockcross/linux-arm64-musl:latest' --format '{{.Repository}}:{{.Tag}}' | grep linux-arm64-musl)
+              docker push $tagged
+            fi
+      - restore_cache:
           key: linux-armv5-assets-{{ .Revision }}
       - deploy:
           name: Deploy linux-armv5
@@ -911,6 +943,9 @@ workflows:
         - linux-arm64:
             requires:
               - base
+        - linux-arm64-musl:
+            requires:
+              - base
         - linux-armv5:
             requires:
               - base
@@ -987,6 +1022,7 @@ workflows:
               - android-arm64
               - web-wasm
               - linux-arm64
+              - linux-arm64-musl
               - linux-armv5
               - linux-armv6
               - linux-armv7

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ ORG = dockcross
 BIN = ./bin
 
 # These images are built using the "build implicit rule"
-STANDARD_IMAGES = linux-s390x android-arm android-arm64 linux-x86 linux-x64 linux-arm64 linux-armv5 linux-armv5-musl linux-armv6 linux-armv7 linux-armv7a linux-mips linux-mipsel linux-ppc64le windows-static-x86 windows-static-x64 windows-static-x64-posix windows-shared-x86 windows-shared-x64 windows-shared-x64-posix
+STANDARD_IMAGES = linux-s390x android-arm android-arm64 linux-x86 linux-x64 linux-arm64 linux-arm64-musl linux-armv5 linux-armv5-musl linux-armv6 linux-armv7 linux-armv7a linux-mips linux-mipsel linux-ppc64le windows-static-x86 windows-static-x64 windows-static-x64-posix windows-shared-x86 windows-shared-x64 windows-shared-x64-posix
 
 # Generated Dockerfiles.
-GEN_IMAGES = linux-s390x linux-mips manylinux1-x64 manylinux1-x86 manylinux2010-x64 manylinux2010-x86 manylinux2014-x64 manylinux2014-x86 manylinux2014-aarch64 web-wasm linux-arm64 windows-static-x86 windows-static-x64 windows-static-x64-posix windows-shared-x86 windows-shared-x64 windows-shared-x64-posix linux-armv7 linux-armv7a linux-armv5 linux-armv5-musl linux-ppc64le
+GEN_IMAGES = linux-s390x linux-mips manylinux1-x64 manylinux1-x86 manylinux2010-x64 manylinux2010-x86 manylinux2014-x64 manylinux2014-x86 manylinux2014-aarch64 web-wasm linux-arm64 linux-arm64-musl windows-static-x86 windows-static-x64 windows-static-x64-posix windows-shared-x86 windows-shared-x64 windows-shared-x64-posix linux-armv7 linux-armv7a linux-armv5 linux-armv5-musl linux-ppc64le
 GEN_IMAGE_DOCKERFILES = $(addsuffix /Dockerfile,$(GEN_IMAGES))
 
 # These images are expected to have explicit rules for *both* build and testing

--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,13 @@ dockcross/linux-arm64
   also known as AArch64.
 
 
+.. |linux-arm64-musl-images| image:: https://images.microbadger.com/badges/image/dockcross/linux-arm64-musl.svg
+  :target: https://microbadger.com/images/dockcross/linux-arm64-musl
+
+dockcross/linux-arm64-musl
+  |linux-arm64-musl-images| Cross compiler for the 64-bit ARM platform on Linux (also known as AArch64), using `musl <https://www.musl-libc.org/>`_ as base "libc".
+
+
 .. |linux-armv5-images| image:: https://images.microbadger.com/badges/image/dockcross/linux-armv5.svg
   :target: https://microbadger.com/images/dockcross/linux-armv5
 

--- a/linux-arm64-musl/Dockerfile.in
+++ b/linux-arm64-musl/Dockerfile.in
@@ -1,0 +1,39 @@
+FROM dockcross/base:latest
+
+ENV XCC_PREFIX /usr/xcc
+ENV CROSS_TRIPLE aarch64-linux-musl
+ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}-cross
+
+RUN mkdir -p ${XCC_PREFIX}
+RUN curl -LO http://musl.cc/${CROSS_TRIPLE}-cross.tgz
+RUN tar -C ${XCC_PREFIX} -xvf ${CROSS_TRIPLE}-cross.tgz
+
+ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
+    AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
+    CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
+    CPP=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-cpp \
+    CXX=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-g++ \
+    LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
+    FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
+
+COPY Toolchain.cmake ${CROSS_ROOT}/
+ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+
+# Linux kernel cross compilation variables
+ENV PATH ${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE ${CROSS_TRIPLE}-
+ENV ARCH arm64
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG IMAGE=dockcross/linux-arm64-musl
+ARG VERSION=latest
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.version=$VERSION \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"
+ENV DEFAULT_DOCKCROSS_IMAGE ${IMAGE}:${VERSION}

--- a/linux-arm64-musl/Toolchain.cmake
+++ b/linux-arm64-musl/Toolchain.cmake
@@ -1,0 +1,17 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+set(cross_triple $ENV{CROSS_TRIPLE})
+set(cross_root $ENV{CROSS_ROOT})
+
+set(CMAKE_C_COMPILER $ENV{CC})
+set(CMAKE_CXX_COMPILER $ENV{CXX})
+set(CMAKE_Fortran_COMPILER $ENV{FC})
+
+set(CMAKE_CXX_FLAGS "-I ${cross_root}/include/")
+
+set(CMAKE_FIND_ROOT_PATH ${cross_root} ${cross_root}/${cross_triple})
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)


### PR DESCRIPTION
This adds a `linux-arm64-musl` image, that leverages the toolchains available on [musl.cc](https://musl.cc).

I realized later that the existing linux-armv5-musl by @thewtex was using crosstool-ng instead, and I don't know what is best. @thewtex any opinion?