### PR TITLE
Add linux-armv7l-musl image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,6 +224,26 @@ jobs:
       - save_cache:
           key: linux-armv7a-assets-{{ .Revision }}
           paths: ~/docker/linux-armv7a.tar
+  linux-armv7l-musl:
+    <<: *build-settings
+    steps:
+      - restore_cache:
+          key: base-assets-{{ .Revision }}
+      - run:
+         name: linux-armv7l-musl build
+         no_output_timeout: 1.5h
+         command: |
+           docker load -i ~/docker/base.tar
+           make linux-armv7l-musl
+           tagged=$(docker images -q -f 'since=dockcross/linux-armv7l-musl:latest' --format '{{.Repository}}:{{.Tag}}' | grep linux-armv7l-musl)
+           docker save -o ~/docker/linux-armv7l-musl.tar dockcross/linux-armv7l-musl:latest $tagged
+      - run:
+         name: linux-armv7l-musl test
+         command: |
+           make linux-armv7l-musl.test
+      - save_cache:
+          key: linux-armv7l-musl-assets-{{ .Revision }}
+          paths: ~/docker/linux-armv7l-musl.tar
   linux-mipsel:
     <<: *build-settings
     steps:
@@ -706,6 +726,18 @@ jobs:
               tagged=$(docker images -q -f 'since=dockcross/linux-armv7a:latest' --format '{{.Repository}}:{{.Tag}}' | grep linux-armv7a)
               docker push $tagged
             fi
+      - restore_cache:
+          key: linux-armv7l-musl-assets-{{ .Revision }}
+      - deploy:
+          name: Deploy linux-armv7l-musl
+          command: |
+            docker load -i ~/docker/linux-armv7l-musl.tar
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              docker login -u $DOCKER_USER -p $DOCKER_PASS
+              docker push dockcross/linux-armv7l-musl:latest
+              tagged=$(docker images -q -f 'since=dockcross/linux-armv7l-musl:latest' --format '{{.Repository}}:{{.Tag}}' | grep linux-armv7l-musl)
+              docker push $tagged
+            fi
       # Image build currently broken. See #209
       #- restore_cache:
           #key: linux-mipsel-assets-{{ .Revision }}
@@ -958,6 +990,9 @@ workflows:
         - linux-armv7a:
             requires:
               - base
+        - linux-armv7l-musl:
+            requires:
+              - base
         # Image build currently broken. See #209
         #- linux-mipsel:
             #requires:
@@ -1027,6 +1062,7 @@ workflows:
               - linux-armv6
               - linux-armv7
               - linux-armv7a
+              - linux-armv7l-musl
               #- linux-mipsel
               - linux-s390x
               #- linux-ppc64le

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ ORG = dockcross
 BIN = ./bin
 
 # These images are built using the "build implicit rule"
-STANDARD_IMAGES = linux-s390x android-arm android-arm64 linux-x86 linux-x64 linux-arm64 linux-arm64-musl linux-armv5 linux-armv5-musl linux-armv6 linux-armv7 linux-armv7a linux-mips linux-mipsel linux-ppc64le windows-static-x86 windows-static-x64 windows-static-x64-posix windows-shared-x86 windows-shared-x64 windows-shared-x64-posix
+STANDARD_IMAGES = linux-s390x android-arm android-arm64 linux-x86 linux-x64 linux-arm64 linux-arm64-musl linux-armv5 linux-armv5-musl linux-armv6 linux-armv7 linux-armv7a linux-armv7l-musl linux-mips linux-mipsel linux-ppc64le windows-static-x86 windows-static-x64 windows-static-x64-posix windows-shared-x86 windows-shared-x64 windows-shared-x64-posix
 
 # Generated Dockerfiles.
-GEN_IMAGES = linux-s390x linux-mips manylinux1-x64 manylinux1-x86 manylinux2010-x64 manylinux2010-x86 manylinux2014-x64 manylinux2014-x86 manylinux2014-aarch64 web-wasm linux-arm64 linux-arm64-musl windows-static-x86 windows-static-x64 windows-static-x64-posix windows-shared-x86 windows-shared-x64 windows-shared-x64-posix linux-armv7 linux-armv7a linux-armv5 linux-armv5-musl linux-ppc64le
+GEN_IMAGES = linux-s390x linux-mips manylinux1-x64 manylinux1-x86 manylinux2010-x64 manylinux2010-x86 manylinux2014-x64 manylinux2014-x86 manylinux2014-aarch64 web-wasm linux-arm64 linux-arm64-musl windows-static-x86 windows-static-x64 windows-static-x64-posix windows-shared-x86 windows-shared-x64 windows-shared-x64-posix linux-armv7 linux-armv7a linux-armv7l-musl linux-armv5 linux-armv5-musl linux-ppc64le
 GEN_IMAGE_DOCKERFILES = $(addsuffix /Dockerfile,$(GEN_IMAGES))
 
 # These images are expected to have explicit rules for *both* build and testing

--- a/README.rst
+++ b/README.rst
@@ -153,7 +153,13 @@ dockcross/linux-armv7
   :target: https://microbadger.com/images/dockcross/linux-armv7a
 
 dockcross/linux-armv7a
-  |linux-armv7a-images| Toolchain configured for ARMv7-A used in Beaglebone Black single board PC with TI SoC AM3358 on board, Cortex-A8.
+  |linux-armv7a-images| Toolchain configured for ARMv7-L, using `musl <https://www.musl-libc.org/>`_ as base "libc".
+
+.. |linux-armv7l-musl-images| image:: https://images.microbadger.com/badges/image/dockcross/linux-armv7l-musl.svg
+  :target: https://microbadger.com/images/dockcross/linux-armv7l-musl
+
+dockcross/linux-armv7l-musl
+  |linux-armv7l-musl-images| Toolchain configured for ARMv7-A used in Beaglebone Black single board PC with TI SoC AM3358 on board, Cortex-A8.
 
 .. |linux-mipsel-images| image:: https://images.microbadger.com/badges/image/dockcross/linux-mipsel.svg
   :target: https://microbadger.com/images/dockcross/linux-mipsel

--- a/linux-armv7l-musl/Dockerfile.in
+++ b/linux-armv7l-musl/Dockerfile.in
@@ -1,0 +1,39 @@
+FROM dockcross/base:latest
+
+ENV XCC_PREFIX /usr/xcc
+ENV CROSS_TRIPLE armv7l-linux-musleabihf
+ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}-cross
+
+RUN mkdir -p ${XCC_PREFIX}
+RUN curl -LO http://musl.cc/${CROSS_TRIPLE}-cross.tgz
+RUN tar -C ${XCC_PREFIX} -xvf ${CROSS_TRIPLE}-cross.tgz
+
+ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
+    AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
+    CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
+    CPP=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-cpp \
+    CXX=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-g++ \
+    LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
+    FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
+
+COPY Toolchain.cmake ${CROSS_ROOT}/
+ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+
+# Linux kernel cross compilation variables
+ENV PATH ${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE ${CROSS_TRIPLE}-
+ENV ARCH arm
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG IMAGE=dockcross/linux-armv7l-musl
+ARG VERSION=latest
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.version=$VERSION \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"
+ENV DEFAULT_DOCKCROSS_IMAGE ${IMAGE}:${VERSION}

--- a/linux-armv7l-musl/Toolchain.cmake
+++ b/linux-armv7l-musl/Toolchain.cmake
@@ -1,0 +1,17 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+set(cross_triple $ENV{CROSS_TRIPLE})
+set(cross_root $ENV{CROSS_ROOT})
+
+set(CMAKE_C_COMPILER $ENV{CC})
+set(CMAKE_CXX_COMPILER $ENV{CXX})
+set(CMAKE_Fortran_COMPILER $ENV{FC})
+
+set(CMAKE_CXX_FLAGS "-I ${cross_root}/include/")
+
+set(CMAKE_FIND_ROOT_PATH ${cross_root} ${cross_root}/${cross_triple})
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)


### PR DESCRIPTION
Adds support for the armv7l toolchain from musl.cc. Very similar to `linux-arm64-musl`.