### PR TITLE
Add linux-armv6-musl image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,6 +184,26 @@ jobs:
       - save_cache:
           key: linux-armv6-assets-{{ .Revision }}
           paths: ~/docker/linux-armv6.tar
+  linux-armv6-musl:
+    <<: *build-settings
+    steps:
+      - restore_cache:
+          key: base-assets-{{ .Revision }}
+      - run:
+         name: linux-armv6-musl build
+         no_output_timeout: 1.5h
+         command: |
+           docker load -i ~/docker/base.tar
+           make linux-armv6-musl
+           tagged=$(docker images -q -f 'since=dockcross/linux-armv6-musl:latest' --format '{{.Repository}}:{{.Tag}}' | grep linux-armv6-musl)
+           docker save -o ~/docker/linux-armv6-musl.tar dockcross/linux-armv6-musl:latest $tagged
+      - run:
+         name: linux-armv6-musl test
+         command: |
+           make linux-armv6-musl.test
+      - save_cache:
+          key: linux-armv6-musl-assets-{{ .Revision }}
+          paths: ~/docker/linux-armv6-musl.tar
   linux-armv7:
     <<: *build-settings
     steps:
@@ -703,6 +723,18 @@ jobs:
               docker push $tagged
             fi
       - restore_cache:
+          key: linux-armv6-musl-assets-{{ .Revision }}
+      - deploy:
+          name: Deploy linux-armv6-musl
+          command: |
+            docker load -i ~/docker/linux-armv6-musl.tar
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              docker login -u $DOCKER_USER -p $DOCKER_PASS
+              docker push dockcross/linux-armv6-musl:latest
+              tagged=$(docker images -q -f 'since=dockcross/linux-armv6-musl:latest' --format '{{.Repository}}:{{.Tag}}' | grep linux-armv6-musl)
+              docker push $tagged
+            fi
+      - restore_cache:
           key: linux-armv7-assets-{{ .Revision }}
       - deploy:
           name: Deploy linux-armv7
@@ -982,6 +1014,9 @@ workflows:
             requires:
               - base
         - linux-armv6:
+            requires:
+              - base
+        - linux-armv6-musl:
             requires:
               - base
         - linux-armv7:

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ ORG = dockcross
 BIN = ./bin
 
 # These images are built using the "build implicit rule"
-STANDARD_IMAGES = linux-s390x android-arm android-arm64 linux-x86 linux-x64 linux-arm64 linux-arm64-musl linux-armv5 linux-armv5-musl linux-armv6 linux-armv7 linux-armv7a linux-armv7l-musl linux-mips linux-mipsel linux-ppc64le windows-static-x86 windows-static-x64 windows-static-x64-posix windows-shared-x86 windows-shared-x64 windows-shared-x64-posix
+STANDARD_IMAGES = linux-s390x android-arm android-arm64 linux-x86 linux-x64 linux-arm64 linux-arm64-musl linux-armv5 linux-armv5-musl linux-armv6 linux-armv6-musl linux-armv7 linux-armv7a linux-armv7l-musl linux-mips linux-mipsel linux-ppc64le windows-static-x86 windows-static-x64 windows-static-x64-posix windows-shared-x86 windows-shared-x64 windows-shared-x64-posix
 
 # Generated Dockerfiles.
-GEN_IMAGES = linux-s390x linux-mips manylinux1-x64 manylinux1-x86 manylinux2010-x64 manylinux2010-x86 manylinux2014-x64 manylinux2014-x86 manylinux2014-aarch64 web-wasm linux-arm64 linux-arm64-musl windows-static-x86 windows-static-x64 windows-static-x64-posix windows-shared-x86 windows-shared-x64 windows-shared-x64-posix linux-armv7 linux-armv7a linux-armv7l-musl linux-armv5 linux-armv5-musl linux-ppc64le
+GEN_IMAGES = linux-s390x linux-mips manylinux1-x64 manylinux1-x86 manylinux2010-x64 manylinux2010-x86 manylinux2014-x64 manylinux2014-x86 manylinux2014-aarch64 web-wasm linux-arm64 linux-arm64-musl windows-static-x86 windows-static-x64 windows-static-x64-posix windows-shared-x86 windows-shared-x64 windows-shared-x64-posix linux-armv7 linux-armv7a linux-armv7l-musl linux-armv6-musl linux-armv5 linux-armv5-musl linux-ppc64le
 GEN_IMAGE_DOCKERFILES = $(addsuffix /Dockerfile,$(GEN_IMAGES))
 
 # These images are expected to have explicit rules for *both* build and testing

--- a/README.rst
+++ b/README.rst
@@ -142,6 +142,13 @@ dockcross/linux-armv6
   Pi, etc.
 
 
+.. |linux-armv6-musl-images| image:: https://images.microbadger.com/badges/image/dockcross/linux-armv6-musl.svg
+  :target: https://microbadger.com/images/dockcross/linux-armv6-musl
+
+dockcross/linux-armv6-musl
+  |linux-armv6-musl-images| Linux ARMv6 cross compiler toolchain for the Raspberry Pi, etc, using `musl <https://www.musl-libc.org/>`_ as base "libc".
+
+
 .. |linux-armv7-images| image:: https://images.microbadger.com/badges/image/dockcross/linux-armv7.svg
   :target: https://microbadger.com/images/dockcross/linux-armv7
 

--- a/linux-armv6-musl/Dockerfile.in
+++ b/linux-armv6-musl/Dockerfile.in
@@ -1,0 +1,39 @@
+FROM dockcross/base:latest
+
+ENV XCC_PREFIX /usr/xcc
+ENV CROSS_TRIPLE armv6-linux-musleabihf
+ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}-cross
+
+RUN mkdir -p ${XCC_PREFIX}
+RUN curl -LO http://musl.cc/${CROSS_TRIPLE}-cross.tgz
+RUN tar -C ${XCC_PREFIX} -xvf ${CROSS_TRIPLE}-cross.tgz
+
+ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
+    AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
+    CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
+    CPP=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-cpp \
+    CXX=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-g++ \
+    LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
+    FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
+
+COPY Toolchain.cmake ${CROSS_ROOT}/
+ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+
+# Linux kernel cross compilation variables
+ENV PATH ${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE ${CROSS_TRIPLE}-
+ENV ARCH arm
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG IMAGE=dockcross/linux-armv6-musl
+ARG VERSION=latest
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.version=$VERSION \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"
+ENV DEFAULT_DOCKCROSS_IMAGE ${IMAGE}:${VERSION}

--- a/linux-armv6-musl/Toolchain.cmake
+++ b/linux-armv6-musl/Toolchain.cmake
@@ -1,0 +1,17 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+set(cross_triple $ENV{CROSS_TRIPLE})
+set(cross_root $ENV{CROSS_ROOT})
+
+set(CMAKE_C_COMPILER $ENV{CC})
+set(CMAKE_CXX_COMPILER $ENV{CXX})
+set(CMAKE_Fortran_COMPILER $ENV{FC})
+
+set(CMAKE_CXX_FLAGS "-I ${cross_root}/include/")
+
+set(CMAKE_FIND_ROOT_PATH ${cross_root} ${cross_root}/${cross_triple})
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)


### PR DESCRIPTION
Following the addition of armv7l-musl and arm64-musl, here is armv6-musl :blush:. Also using the toolchain from musl.cc.