### PR TITLE
:sparkles: Switched to gcc10.2 for windows

### DIFF
--- a/common.windows
+++ b/common.windows
@@ -15,8 +15,8 @@
 #  ARG MXE_TARGET_LINK=shared
 #
 
-# mxe master 2019-12-06
-ARG MXE_GIT_TAG=aab04b93b06892a3dc675c97653236a40858c4a3
+# mxe master 2020-12-21
+ARG MXE_GIT_TAG=a7a45e4e51fe70032305b828a001aac848f74fdb
 
 ENV CMAKE_TOOLCHAIN_FILE /usr/src/mxe/usr/${MXE_TARGET_ARCH}-w64-mingw32.${MXE_TARGET_LINK}${MXE_TARGET_THREAD}/share/cmake/mxe-conf.cmake
 
@@ -88,7 +88,7 @@ RUN \
   cd /usr/src/mxe && \
   echo "MXE_TARGETS := ${MXE_TARGET_ARCH}-w64-mingw32.${MXE_TARGET_LINK}${MXE_TARGET_THREAD}" > settings.mk && \
   echo "MXE_USE_CCACHE :="                                                       >> settings.mk && \
-  echo "MXE_PLUGIN_DIRS := plugins/gcc9"                                         >> settings.mk && \
+  echo "MXE_PLUGIN_DIRS := plugins/gcc10"                                        >> settings.mk && \
   echo "LOCAL_PKG_LIST := cc cmake"                                              >> settings.mk && \
   echo ".DEFAULT local-pkg-list:"                                                >> settings.mk && \
   echo "local-pkg-list: \$(LOCAL_PKG_LIST)"                                      >> settings.mk && \


### PR DESCRIPTION
I propose to switch from gcc9.2, because I encounter runtime errors with recursive subroutine in fortran.

With version 10.2, these runtime errors have gone away