### PR TITLE
manylinux: Build pip with cp38

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ manylinux2014-aarch64: manylinux2014-aarch64/Dockerfile
 
 manylinux2014-aarch64.test: manylinux2014-aarch64
 	$(DOCKER) run $(RM) dockcross/manylinux2014-aarch64 > $(BIN)/dockcross-manylinux2014-aarch64 && chmod +x $(BIN)/dockcross-manylinux2014-aarch64
-	$(BIN)/dockcross-manylinux2014-aarch64 /opt/python/cp35-cp35m/bin/python test/run.py
+	$(BIN)/dockcross-manylinux2014-aarch64 /opt/python/cp38-cp38/bin/python test/run.py
 
 #
 # manylinux2014-x64
@@ -145,7 +145,7 @@ manylinux2014-x64: manylinux2014-x64/Dockerfile
 
 manylinux2014-x64.test: manylinux2014-x64
 	$(DOCKER) run $(RM) dockcross/manylinux2014-x64 > $(BIN)/dockcross-manylinux2014-x64 && chmod +x $(BIN)/dockcross-manylinux2014-x64
-	$(BIN)/dockcross-manylinux2014-x64 /opt/python/cp35-cp35m/bin/python test/run.py
+	$(BIN)/dockcross-manylinux2014-x64 /opt/python/cp38-cp38/bin/python test/run.py
 
 #
 # manylinux2014-x86
@@ -169,7 +169,7 @@ manylinux2014-x86: manylinux2014-x86/Dockerfile
 
 manylinux2014-x86.test: manylinux2014-x86
 	$(DOCKER) run $(RM) dockcross/manylinux2014-x86 > $(BIN)/dockcross-manylinux2014-x86 && chmod +x $(BIN)/dockcross-manylinux2014-x86
-	$(BIN)/dockcross-manylinux2014-x86 /opt/python/cp35-cp35m/bin/python test/run.py
+	$(BIN)/dockcross-manylinux2014-x86 /opt/python/cp38-cp38/bin/python test/run.py
 
 #
 # manylinux2010-x64
@@ -194,7 +194,7 @@ manylinux2010-x64: manylinux2010-x64/Dockerfile
 
 manylinux2010-x64.test: manylinux2010-x64
 	$(DOCKER) run $(RM) dockcross/manylinux2010-x64 > $(BIN)/dockcross-manylinux2010-x64 && chmod +x $(BIN)/dockcross-manylinux2010-x64
-	$(BIN)/dockcross-manylinux2010-x64 /opt/python/cp35-cp35m/bin/python test/run.py
+	$(BIN)/dockcross-manylinux2010-x64 /opt/python/cp38-cp38/bin/python test/run.py
 
 #
 # manylinux2010-x86
@@ -219,7 +219,7 @@ manylinux2010-x86: manylinux2010-x86/Dockerfile
 
 manylinux2010-x86.test: manylinux2010-x86
 	$(DOCKER) run $(RM) dockcross/manylinux2010-x86 > $(BIN)/dockcross-manylinux2010-x86 && chmod +x $(BIN)/dockcross-manylinux2010-x86
-	$(BIN)/dockcross-manylinux2010-x86 /opt/python/cp35-cp35m/bin/python test/run.py
+	$(BIN)/dockcross-manylinux2010-x86 /opt/python/cp38-cp38/bin/python test/run.py
 
 #
 # manylinux1-x64
@@ -244,7 +244,7 @@ manylinux1-x64: manylinux1-x64/Dockerfile
 
 manylinux1-x64.test: manylinux1-x64
 	$(DOCKER) run $(RM) dockcross/manylinux1-x64 > $(BIN)/dockcross-manylinux1-x64 && chmod +x $(BIN)/dockcross-manylinux1-x64
-	$(BIN)/dockcross-manylinux1-x64 /opt/python/cp35-cp35m/bin/python test/run.py
+	$(BIN)/dockcross-manylinux1-x64 /opt/python/cp38-cp38/bin/python test/run.py
 
 #
 # manylinux1-x86
@@ -269,7 +269,7 @@ manylinux1-x86: manylinux1-x86/Dockerfile
 
 manylinux1-x86.test: manylinux1-x86
 	$(DOCKER) run $(RM) dockcross/manylinux1-x86 > $(BIN)/dockcross-manylinux1-x86 && chmod +x $(BIN)/dockcross-manylinux1-x86
-	$(BIN)/dockcross-manylinux1-x86 /opt/python/cp35-cp35m/bin/python test/run.py
+	$(BIN)/dockcross-manylinux1-x86 /opt/python/cp38-cp38/bin/python test/run.py
 
 #
 # base

--- a/common.docker
+++ b/common.docker
@@ -25,7 +25,7 @@ RUN \
   /buildscripts/build-and-install-git.sh && \
   /buildscripts/install-cmake-binary.sh $X86_FLAG && \
   /buildscripts/install-liquidprompt-binary.sh && \
-  PYTHON=$([ -e /opt/python/cp35-cp35m/bin/python ] && echo "/opt/python/cp35-cp35m/bin/python" || echo "python") && \
+  PYTHON=$([ -e /opt/python/cp38-cp38/bin/python ] && echo "/opt/python/cp38-cp38/bin/python" || echo "python") && \
   /buildscripts/install-python-packages.sh -python ${PYTHON} && \
   /buildscripts/build-and-install-ninja.sh -python ${PYTHON} && \
   rm -rf /buildscripts

--- a/imagefiles/install-python-packages.sh
+++ b/imagefiles/install-python-packages.sh
@@ -20,7 +20,10 @@ done
 
 cd /tmp
 
-curl -# -LO https://bootstrap.pypa.io/get-pip.py
+# Todo: Need to update base image from Debian Stretch for the required Python
+# 3.6 or later
+# curl -# -LO https://bootstrap.pypa.io/get-pip.py
+curl -# -LO https://bootstrap.pypa.io/2.7/get-pip.py
 ${PYTHON} get-pip.py --ignore-installed
 rm get-pip.py
 


### PR DESCRIPTION
cp35 is no longer supported and get-pip.py fails to build.