### PR TITLE
Fix "yum" on manylinux2014-x86

### DIFF
--- a/manylinux2014-x86/Dockerfile.in
+++ b/manylinux2014-x86/Dockerfile.in
@@ -13,7 +13,7 @@ ENV DEFAULT_DOCKCROSS_IMAGE dockcross/manylinux2014-x86
 # Override yum to work around the problem with newly built libcurl.so.4
 # https://access.redhat.com/solutions/641093
 RUN echo $'#!/bin/bash\n\
-LD_PRELOAD=/usr/lib64/libcurl.so.4 /usr/bin/yum "$@"' > /usr/local/bin/yum && chmod a+x /usr/local/bin/yum
+LD_PRELOAD=/usr/lib/libcurl.so.4 /usr/bin/yum "$@"' > /usr/local/bin/yum && chmod a+x /usr/local/bin/yum
 
 ENV CROSS_TRIPLE i686-linux-gnu
 ENV CROSS_ROOT /opt/rh/devtoolset-9/root/usr/bin


### PR DESCRIPTION
Dear @thewtex,

this fixes your workaround from #377, but this time for the 32-bit `manylinux2014-x86` image. It will resolve #467.

With kind regards,
Andreas.

cc @figroc, @JonasVautherin, @zborowa
