### PR TITLE
Tag base image like the others

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,16 @@ manylinux1-x86.test: manylinux1-x86
 base: Dockerfile imagefiles/
 	$(DOCKER) build -t $(ORG)/base:latest \
 		--build-arg IMAGE=$(ORG)/base \
+		--build-arg VCS_REF=`git rev-parse --short HEAD` \
 		--build-arg VCS_URL=`git config --get remote.origin.url` \
+		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+		.
+	$(DOCKER) build -t $(ORG)/base:$(TAG) \
+		--build-arg IMAGE=$(ORG)/base \
+		--build-arg VERSION=$(TAG) \
+		--build-arg VCS_REF=`git rev-parse --short HEAD` \
+		--build-arg VCS_URL=`git config --get remote.origin.url` \
+		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
 		.
 
 base.test: base

--- a/Makefile
+++ b/Makefile
@@ -278,16 +278,12 @@ manylinux1-x86.test: manylinux1-x86
 base: Dockerfile imagefiles/
 	$(DOCKER) build -t $(ORG)/base:latest \
 		--build-arg IMAGE=$(ORG)/base \
-		--build-arg VCS_REF=`git rev-parse --short HEAD` \
 		--build-arg VCS_URL=`git config --get remote.origin.url` \
-		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
 		.
 	$(DOCKER) build -t $(ORG)/base:$(TAG) \
 		--build-arg IMAGE=$(ORG)/base \
 		--build-arg VERSION=$(TAG) \
-		--build-arg VCS_REF=`git rev-parse --short HEAD` \
 		--build-arg VCS_URL=`git config --get remote.origin.url` \
-		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
 		.
 
 base.test: base


### PR DESCRIPTION
Following the discussion in https://github.com/dockbuild/dockbuild/issues/69, I wanted to tag the base image like it is done for the other images, but I'm getting the following error (which I thought had been fixed recently :thinking:):

```
+ rm -f cmake-3.17.1-Centos5-x86_64.tar.gz
+ cd cmake-3.17.1-Centos5-x86_64
+ rm -rf doc man
+ rm -rf bin/cmake-gui
+ find . -type f -exec install -D '{}' '/usr/{}' ';'
+ command -v git
+ cd /usr/share
+ rm -rf liquidprompt
+ git clone https://github.com/nojhan/liquidprompt.git -b v_1.11
Cloning into 'liquidprompt'...
+ cat
+ chmod u+x /root/.bashrc
######################################################################## 100.0%

Hi there!

The URL you are using to fetch this script has changed, and this one will no
longer work. Please use get-pip.py from the following URL instead:

    https://bootstrap.pypa.io/pip/2.7/get-pip.py

Sorry if this change causes any inconvenience for you!
```