### PR TITLE
Define CMAKE_SYSTEM_PROCESSOR in Toolchain.cmake for Android build.

### DIFF
--- a/android-arm/Toolchain.cmake
+++ b/android-arm/Toolchain.cmake
@@ -1,5 +1,6 @@
 set(CMAKE_SYSTEM_NAME Android)
 set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR armv7-a)
 set(CMAKE_ANDROID_ARCH_ABI armeabi-v7a)
 
 set(cross_triple arm-linux-androideabi)

--- a/android-arm64/Toolchain.cmake
+++ b/android-arm64/Toolchain.cmake
@@ -1,5 +1,6 @@
 set(CMAKE_SYSTEM_NAME Android)
 set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
 set(CMAKE_ANDROID_ARCH_ABI arm64-v8a)
 
 set(cross_triple aarch64-linux-android)

--- a/android-x86/Toolchain.cmake
+++ b/android-x86/Toolchain.cmake
@@ -1,5 +1,6 @@
 set(CMAKE_SYSTEM_NAME Android)
 set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR i686)
 set(CMAKE_ANDROID_ARCH_ABI x86)
 
 set(cross_triple i686-linux-android)

--- a/android-x86_64/Toolchain.cmake
+++ b/android-x86_64/Toolchain.cmake
@@ -1,5 +1,6 @@
 set(CMAKE_SYSTEM_NAME Android)
 set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
 set(CMAKE_ANDROID_ARCH_ABI x86_64)
 
 set(cross_triple x86_64-linux-android)


### PR DESCRIPTION
`CMAKE_SYSTEM_PROCESSOR` is defined in the `android.toolchain.cmake` offered by Android NDK.
But it's not defined in `Toolchain.cmake`.