### PR TITLE
fix: crosstool-ng expat dowload

### DIFF
--- a/common-manylinux.crosstool
+++ b/common-manylinux.crosstool
@@ -47,6 +47,7 @@ ENV XCC_PREFIX=/usr/xcc
 # for users.
 COPY \
   imagefiles/install-crosstool-ng-toolchain.sh \
+  imagefiles/crosstool-ng-expat.patch \
   manylinux2014-aarch64/crosstool-ng.config \
   /dockcross/
 

--- a/common.crosstool
+++ b/common.crosstool
@@ -32,6 +32,7 @@ ENV XCC_PREFIX=/usr/xcc
 # for users.
 COPY \
   imagefiles/install-crosstool-ng-toolchain.sh \
+  imagefiles/crosstool-ng-expat.patch \
   crosstool-ng.config \
   /dockcross/
 

--- a/imagefiles/crosstool-ng-expat.patch
+++ b/imagefiles/crosstool-ng-expat.patch
@@ -1,0 +1,11 @@
+--- crosstool-ng-crosstool-ng-1.23.0/scripts/build/companion_libs/210-expat.sh	2021-04-05 13:55:31.047130000 +0000
++++ crosstool-ng-crosstool-ng-1.23.0/scripts/build/companion_libs/210-expat.sh.new	2021-04-05 13:57:13.841170000 +0000
+@@ -10,7 +10,7 @@
+ 
+ do_expat_get() {
+     CT_GetFile "expat-${CT_EXPAT_VERSION}" .tar.gz    \
+-               http://downloads.sourceforge.net/project/expat/expat/${CT_EXPAT_VERSION}
++               https://github.com/libexpat/libexpat/releases/download/R_${CT_EXPAT_VERSION//./_}
+ }
+ 
+ do_expat_extract() {

--- a/imagefiles/install-crosstool-ng-toolchain.sh
+++ b/imagefiles/install-crosstool-ng-toolchain.sh
@@ -61,6 +61,7 @@ REV=1.23.0
 curl -# -LO \
   "https://github.com/crosstool-ng/crosstool-ng/archive/crosstool-ng-${REV}.tar.gz"
 tar -xf "crosstool-ng-${REV}.tar.gz"
+patch crosstool-ng-crosstool-ng-1.23.0/scripts/build/companion_libs/210-expat.sh -i /dockcross/crosstool-ng-expat.patch
 cd "crosstool-ng-crosstool-ng-${REV}"
 
 # Bootstrap and install the tool.


### PR DESCRIPTION
expat shall now be downloaded from github rather than sourceforge.
This commit patches crosstool-ng 1.23.0 to do this.

Pre-requisite to #482 

Fix #429