### PR TITLE
Improve install-crosstool-ng-toolchain.sh script

### DIFF
--- a/common.crosstool
+++ b/common.crosstool
@@ -42,6 +42,7 @@ RUN mkdir /dockcross/crosstool \
 && /dockcross/install-crosstool-ng-toolchain.sh \
   -p "${XCC_PREFIX}" \
   -c /dockcross/crosstool-ng.config \
+  -v "${CT_VERSION}" \
 && rm -rf /dockcross/crosstool /dockcross/install-crosstool-ng-toolchain.sh
 
 # Restore our default workdir (from "dockcross/base").

--- a/linux-arm64/Dockerfile.in
+++ b/linux-arm64/Dockerfile.in
@@ -2,6 +2,9 @@ FROM dockcross/base:latest
 
 # This is for 64-bit ARM Linux machine
 
+# Crosstool-ng version
+ENV CT_VERSION crosstool-ng-1.23.0
+
 #include "common.crosstool"
 
 # The cross-compiling emulator

--- a/linux-armv5/Dockerfile.in
+++ b/linux-armv5/Dockerfile.in
@@ -4,6 +4,9 @@ MAINTAINER Matt McCormick "matt.mccormick@kitware.com"
 # This is for ARMv5 "legacy" (armel) devices which do NOT support hard float
 # VFP instructions (armhf).
 
+# Crosstool-ng version
+ENV CT_VERSION crosstool-ng-1.23.0
+
 #include "common.crosstool"
 
 # The cross-compiling emulator

--- a/linux-armv7/Dockerfile.in
+++ b/linux-armv7/Dockerfile.in
@@ -1,6 +1,9 @@
 FROM dockcross/base:latest
 MAINTAINER Matt McCormick "matt.mccormick@kitware.com"
 
+# Crosstool-ng version
+ENV CT_VERSION crosstool-ng-1.23.0
+
 # This is for 32-bit ARMv7 Linux
 #include "common.crosstool"
 

--- a/linux-armv7a/Dockerfile.in
+++ b/linux-armv7a/Dockerfile.in
@@ -2,6 +2,10 @@ FROM dockcross/base:latest
 MAINTAINER Matt McCormick "matt.mccormick@kitware.com"
 
 # This is for 32-bit ARMv7 Linux
+
+# Crosstool-ng version
+ENV CT_VERSION crosstool-ng-1.23.0
+
 #include "common.crosstool"
 
 # The cross-compiling emulator

--- a/linux-mips/Dockerfile.in
+++ b/linux-mips/Dockerfile.in
@@ -2,6 +2,9 @@ FROM dockcross/base:latest
 
 # This is for 32-bit Big-Endian MIPS devices with hard floating point enabled
 
+# Crosstool-ng version
+ENV CT_VERSION crosstool-ng-1.23.0
+
 #include "common.crosstool"
 
 # The cross-compiling emulator

--- a/linux-ppc64le/Dockerfile.in
+++ b/linux-ppc64le/Dockerfile.in
@@ -1,6 +1,9 @@
 FROM dockcross/base:latest
 MAINTAINER Matt McCormick "matt.mccormick@kitware.com"
 
+# Crosstool-ng version
+ENV CT_VERSION crosstool-ng-1.23.0
+
 #include "common.crosstool"
 
 ENV CROSS_TRIPLE powerpc64le-linux-gnu

--- a/linux-s390x/Dockerfile.in
+++ b/linux-s390x/Dockerfile.in
@@ -2,6 +2,9 @@ FROM dockcross/base:latest
 
 # This is for 64-bit S390X Linux machine
 
+# Crosstool-ng version
+ENV CT_VERSION crosstool-ng-1.23.0
+
 #include "common.crosstool"
 
 # The cross-compiling emulator


### PR DESCRIPTION
It is now possible to choose the version of crosstool-ng per image, To make it easier to upgrade crosstool-ng to newer versions without having to update all images at the same time

Signed-off-by: Bensuperpc <bensuperpc@gmail.com>