### PR TITLE
Fix error on manylinux2014-aarch64

### DIFF
--- a/imagefiles/install-crosstool-ng-toolchain.sh
+++ b/imagefiles/install-crosstool-ng-toolchain.sh
@@ -111,6 +111,9 @@ cp "${CONFIG_PATH}" "${BUILD}/.config"
 
 # As mentioned in ct-ng config, need to unset LD_LIBRARY_PATH.
 unset LD_LIBRARY_PATH
+# Fix build error on manylinux2014-aarch64
+unset CC
+unset CXX
 
 # Build and install the toolchain!
 # Print last 250 lines if build fail

--- a/manylinux2014-aarch64/Dockerfile.in
+++ b/manylinux2014-aarch64/Dockerfile.in
@@ -6,6 +6,10 @@ FROM dockcross/manylinux2014-x64
 
 # This is for 64-bit ARM Manylinux machine
 
+# Crosstool-ng version
+# Issues with crosstool-ng-1.24.0 and up : https://github.com/dockcross/dockcross/issues/367
+ENV CT_VERSION crosstool-ng-1.23.0
+
 #include "common-manylinux.crosstool"
 
 # The cross-compiling emulator


### PR DESCRIPTION
Fix error on manylinux2014-aarch64

I tried with newer versions of crosstool-ng and GCC, but encountered many problems: https://github.com/dockcross/dockcross/issues/367

Signed-off-by: Bensuperpc <bensuperpc@gmail.com>