### PR TITLE
Update windows images to GCC 11.1

### DIFF
--- a/common/common.windows
+++ b/common/common.windows
@@ -88,7 +88,7 @@ RUN \
   cd /usr/src/mxe && \
   echo "MXE_TARGETS := ${MXE_TARGET_ARCH}-w64-mingw32.${MXE_TARGET_LINK}${MXE_TARGET_THREAD}" > settings.mk && \
   echo "MXE_USE_CCACHE :="                                                       >> settings.mk && \
-  echo "MXE_PLUGIN_DIRS := plugins/gcc10"                                        >> settings.mk && \
+  echo "MXE_PLUGIN_DIRS := plugins/gcc11"                                        >> settings.mk && \
   echo "LOCAL_PKG_LIST := cc cmake"                                              >> settings.mk && \
   echo ".DEFAULT local-pkg-list:"                                                >> settings.mk && \
   echo "local-pkg-list: \$(LOCAL_PKG_LIST)"                                      >> settings.mk && \


### PR DESCRIPTION
Update windows images to GCC 11.1 (From 10.x)
- Better support C++20 and C++17 by default
- Add support alderlake and znver3 (Ryzen 5xxx)

Source: https://gcc.gnu.org/gcc-11/changes.html