### PR TITLE
Remove cpp, allow gcc -E fallback

### DIFF
--- a/windows-arm64/Dockerfile.in
+++ b/windows-arm64/Dockerfile.in
@@ -12,9 +12,8 @@ RUN mkdir -p ${CROSS_ROOT} && wget -qO- "${DOWNLOAD_URL}" | tar xJvf - --strip 1
 
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
-    CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-clang \
-    CPP=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-cpp \
-    CXX=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-clang++ \
+    CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
+    CXX=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-g++ \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 

--- a/windows-armv7/Dockerfile.in
+++ b/windows-armv7/Dockerfile.in
@@ -12,9 +12,8 @@ RUN mkdir -p ${CROSS_ROOT} && wget -qO- "${DOWNLOAD_URL}" | tar xJvf - --strip 1
 
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
-    CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-clang \
-    CPP=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-cpp \
-    CXX=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-clang++ \
+    CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
+    CXX=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-g++ \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 


### PR DESCRIPTION
Fixes newly introduced `llvm-mingw` builds as introduced in #557 

* Toolchain wrapper `llvm-mingw` doesn't provide a C preprocessor/precompiler (a.k.a. `CPP`), therefore it shouldn't be specified
* Removing `ENV CPP` allows `make` to fallback to `gcc -E`, which is normal behavior (this succeeds)
* `clang++` is technically valid, but is not an mingw-w64 "familiar" suffix, changed to `gcc`, `g++` for standardization (For example, if you unset all variables, the compiler will predict them as `gcc`, `g++`, not as `clang`, `clang++`)

See also: https://github.com/dockcross/dockcross/pull/557#pullrequestreview-727862804

**Warning/Note:** I'm not sure how to locally test this change.  (I know very little about Docker and my environment seems to be stuck on upstream at time of writing this)