### PR TITLE
Move to llvm for NDK 23

### DIFF
--- a/android-arm/Dockerfile.in
+++ b/android-arm/Dockerfile.in
@@ -9,13 +9,11 @@ RUN apt-get update && apt-get install -y \
 
 ENV CROSS_TRIPLE=arm-linux-androideabi
 ENV CROSS_ROOT=/usr/${CROSS_TRIPLE}
-ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
-    AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
-    CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-clang \
-    CPP=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-cpp \
-    CXX=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-clang++ \
-    LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
-    FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
+ENV AS=${CROSS_ROOT}/bin/llvm-as \
+    AR=${CROSS_ROOT}/bin/llvm-ar \
+    CC=${CROSS_ROOT}/bin/clang \
+    CXX=${CROSS_ROOT}/bin/clang++ \
+    LD=${CROSS_ROOT}/bin/ld
 
 ENV ANDROID_NDK_REVISION 23
 ENV ANDROID_NDK_API 23

--- a/android-arm64/Dockerfile.in
+++ b/android-arm64/Dockerfile.in
@@ -13,13 +13,11 @@ RUN apt-get update && apt-get install -y \
 
 ENV CROSS_TRIPLE=aarch64-linux-android
 ENV CROSS_ROOT=/usr/${CROSS_TRIPLE}
-ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
-    AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
-    CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-clang \
-    CPP=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-cpp \
-    CXX=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-clang++ \
-    LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
-    FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
+ENV AS=${CROSS_ROOT}/bin/llvm-as \
+    AR=${CROSS_ROOT}/bin/llvm-ar \
+    CC=${CROSS_ROOT}/bin/clang \
+    CXX=${CROSS_ROOT}/bin/clang++ \
+    LD=${CROSS_ROOT}/bin/ld
 
 ENV ANDROID_NDK_REVISION 23
 ENV ANDROID_NDK_API 23

--- a/android-x86/Dockerfile
+++ b/android-x86/Dockerfile
@@ -4,13 +4,11 @@ RUN apt-get update && apt-get install -y unzip
 
 ENV CROSS_TRIPLE=i686-linux-android
 ENV CROSS_ROOT=/usr/${CROSS_TRIPLE}
-ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
-    AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
-    CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-clang \
-    CPP=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-cpp \
-    CXX=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-clang++ \
-    LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
-    FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
+ENV AS=${CROSS_ROOT}/bin/llvm-as \
+    AR=${CROSS_ROOT}/bin/llvm-ar \
+    CC=${CROSS_ROOT}/bin/clang \
+    CXX=${CROSS_ROOT}/bin/clang++ \
+    LD=${CROSS_ROOT}/bin/ld
 
 ENV ANDROID_NDK_REVISION 23
 ENV ANDROID_NDK_API 23

--- a/android-x86_64/Dockerfile
+++ b/android-x86_64/Dockerfile
@@ -4,13 +4,11 @@ RUN apt-get update && apt-get install -y unzip
 
 ENV CROSS_TRIPLE=x86_64-linux-android
 ENV CROSS_ROOT=/usr/${CROSS_TRIPLE}
-ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
-    AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
-    CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-clang \
-    CPP=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-cpp \
-    CXX=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-clang++ \
-    LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
-    FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
+ENV AS=${CROSS_ROOT}/bin/llvm-as \
+    AR=${CROSS_ROOT}/bin/llvm-ar \
+    CC=${CROSS_ROOT}/bin/clang \
+    CXX=${CROSS_ROOT}/bin/clang++ \
+    LD=${CROSS_ROOT}/bin/ld
 
 ENV ANDROID_NDK_REVISION 23
 ENV ANDROID_NDK_API 23


### PR DESCRIPTION
This seems to fix my builds. Not sure what the consequences of removing `FC` and `CPP` are, but they don't seem to be in the NDK 23 toolchains anymore...

Resolves #568.