### PR TITLE
chore: bump openssl 1.1.1i → 1.1.1l

### DIFF
--- a/imagefiles/build-and-install-openssl.sh
+++ b/imagefiles/build-and-install-openssl.sh
@@ -47,9 +47,9 @@ source $MY_DIR/utils.sh
 # copied from https://github.com/pypa/manylinux/tree/master/docker/build_scripts
 #
 
-OPENSSL_ROOT=openssl-1.1.1i
-# Hash from https://www.openssl.org/source/openssl-1.1.1i.tar.gz.sha256
-OPENSSL_HASH=e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242
+OPENSSL_ROOT=openssl-1.1.1l
+# Hash from https://www.openssl.org/source/openssl-1.1.1l.tar.gz.sha256
+OPENSSL_HASH=0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1
 OPENSSL_DOWNLOAD_URL=http://www.openssl.org/source/
 
 # a recent enough perl is needed to build openssl


### PR DESCRIPTION
0b8587b72a5e9ce9aac7b3b086150051bb8276fa /  #574 downgraded openssl from 1.1.1k to 1.1.1i for some reason.