### PR TITLE
imagefiles: gosu sudo wrapper requires bash

### DIFF
--- a/imagefiles/install-gosu-binary-wrapper.sh
+++ b/imagefiles/install-gosu-binary-wrapper.sh
@@ -16,7 +16,7 @@ gosu nobody true
 # is created in /usr/local/bin
 
 cat << EOF >> /usr/local/bin/sudo
-#!/bin/sh
+#!/bin/bash
 # Emulate the sudo command
 SUDO_USER=root
 SUDO_GROUP=root


### PR DESCRIPTION
Addresses:

  /usr/local/bin/sudo: 5: 2: not found

that occurs during sudo execution.
