### PR TITLE
add osslsigncode tool for Windows

### DIFF
--- a/common/common.debian
+++ b/common/common.debian
@@ -18,6 +18,7 @@ RUN \
     gettext \
     gzip \
     gnupg \
+    osslsigncode \
     initramfs-tools \
     libncurses5 \
     libtool \

--- a/common/common.windows
+++ b/common/common.windows
@@ -56,6 +56,7 @@ RUN \
     make \
     nsis \
     openssl \
+    osslsigncode \
     p7zip-full \
     patch \
     perl \

--- a/web-wasm/Dockerfile.in
+++ b/web-wasm/Dockerfile.in
@@ -33,6 +33,7 @@ RUN \
     libtool \
     python3 \
     python3-pip \
+    osslsigncode \
     rsync \
     sed \
     ssh \


### PR DESCRIPTION
Code-signing of generated executables is usually done with "signtool" on
Windows. When cross-compiling on Linux this tool is not available,
however, osslsigncode can be used as an replacement.

This patch simply apt-get installs osslsigncode to make it available inside the container.