### PR TITLE
web-wasi: Update emulator path

### DIFF
--- a/web-wasi/Toolchain.cmake
+++ b/web-wasi/Toolchain.cmake
@@ -7,4 +7,4 @@ set(CMAKE_SYSROOT $ENV{WASI_SYSROOT})
 set(CMAKE_C_COMPILER /usr/local/bin/clang-wasi-sysroot.sh)
 set(CMAKE_CXX_COMPILER /usr/local/bin/clang++-wasi-sysroot.sh)
 
-set(CMAKE_CROSSCOMPILING_EMULATOR /usr/local/bin/wasmtime-pwd.sh)
+set(CMAKE_CROSSCOMPILING_EMULATOR /wasi-runtimes/wasmtime/bin/wasmtime-pwd.sh)


### PR DESCRIPTION
This was changed in the web-wasm/web-wasi common tooling additions and
refactoring.
