### PR TITLE
add flatcc to Dockcross base image

### DIFF
--- a/common/common.docker
+++ b/common/common.docker
@@ -2,11 +2,13 @@ WORKDIR /usr/src
 
 ARG GIT_VERSION=2.32.0
 ARG CMAKE_VERSION=3.21.1
+ARG FLATCC_VERSION=0.6.0
 
 # Image build scripts
 COPY \
   imagefiles/build-and-install-cmake.sh \
   imagefiles/build-and-install-curl.sh \
+  imagefiles/build-and-install-flatcc.sh \
   imagefiles/build-and-install-git.sh \
   imagefiles/build-and-install-ninja.sh \
   imagefiles/build-and-install-openssl.sh \
@@ -28,6 +30,7 @@ RUN \
   PYTHON=$([ -e /opt/python/cp38-cp38/bin/python ] && echo "/opt/python/cp38-cp38/bin/python" || echo "python3") && \
   /buildscripts/install-python-packages.sh -python ${PYTHON} && \
   /buildscripts/build-and-install-ninja.sh -python ${PYTHON} && \
+  /buildscripts/build-and-install-flatcc.sh && \
   rm -rf /buildscripts
 
 RUN echo "root:root" | chpasswd

--- a/imagefiles/build-and-install-flatcc.sh
+++ b/imagefiles/build-and-install-flatcc.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -ex
+
+if ! command -v git &> /dev/null; then
+	echo >&2 'error: "git" not found!'
+	exit 1
+fi
+
+if [[ "${FLATCC_VERSION}" == "" ]]; then
+  echo >&2 'error: FLATCC_VERSION env. variable must be set to a non-empty value'
+  exit 1
+fi
+
+cd /usr/src
+
+git clone https://github.com/dvidelabs/flatcc.git flatcc -b v$FLATCC_VERSION --depth 1
+
+cd flatcc
+
+cmake -DFLATCC_INSTALL=on && make install > /dev/null
+
+./scripts/cleanall.sh


### PR DESCRIPTION
add flatcc to dockcross base image

Flatcc is a compiler that generates FlatBuffers code for C given a FlatBuffer schema file

see:
https://github.com/dvidelabs/flatcc
https://google.github.io/flatbuffers/

associated ticket: https://github.com/dockcross/dockcross/issues/668