### PR TITLE
Fix build for non-x86 archtectures and update GOSU

### DIFF
--- a/imagefiles/install-gosu-binary.sh
+++ b/imagefiles/install-gosu-binary.sh
@@ -13,8 +13,8 @@ if ! command -v gpg &> /dev/null; then
 	exit 1
 fi
 
-GOSU_VERSION=1.12
-dpkgArch=$(if test "$(uname -m)" = "x86_64"; then echo amd64; else echo i386; fi)
+GOSU_VERSION=1.14
+dpkgArch=$(dpkg --print-architecture)
 url="https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}"
 url_key="https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}.asc"
 

--- a/imagefiles/install-gosu-binary.sh
+++ b/imagefiles/install-gosu-binary.sh
@@ -13,7 +13,7 @@ if ! command -v gpg &> /dev/null; then
 	exit 1
 fi
 
-GOSU_VERSION=1.14
+GOSU_VERSION=1.13
 dpkgArch=$(dpkg --print-architecture)
 url="https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}"
 url_key="https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}.asc"


### PR DESCRIPTION
Fix build for non-x86 archtectures (By paleozogt) and update GOSU to 1.13 Fix: #639 

Signed-off-by: Bensuperpc <bensuperpc@gmail.com>