### PR TITLE
Improve podman support

### DIFF
--- a/imagefiles/dockcross.sh
+++ b/imagefiles/dockcross.sh
@@ -24,10 +24,10 @@ has() {
 
 # If OCI_EXE is not already set, search for a container executor (OCI stands for "Open Container Initiative")
 if [ -z "$OCI_EXE" ]; then
-    if which docker >/dev/null 2>/dev/null; then
-        OCI_EXE=docker
-    elif which podman >/dev/null 2>/dev/null; then
+    if which podman >/dev/null 2>/dev/null; then
         OCI_EXE=podman
+    elif which docker >/dev/null 2>/dev/null; then
+        OCI_EXE=docker
     else
         die "Cannot find a container executor. Search for docker and podman."
     fi

--- a/imagefiles/dockcross.sh
+++ b/imagefiles/dockcross.sh
@@ -190,7 +190,7 @@ MSYS=$([ -e /proc/version ] && grep -l MINGW /proc/version || echo "")
 # CYGWIN
 CYGWIN=$([ -e /proc/version ] && grep -l CYGWIN /proc/version || echo "")
 
-if [ -z "$UBUNTU_ON_WINDOWS" -a -z "$MSYS" ]; then
+if [ -z "$UBUNTU_ON_WINDOWS" -a -z "$MSYS" -a "$OCI_EXE" != "podman" ]; then
     USER_IDS=(-e BUILDER_UID="$( id -u )" -e BUILDER_GID="$( id -g )" -e BUILDER_USER="$( id -un )" -e BUILDER_GROUP="$( id -gn )")
 fi
 


### PR DESCRIPTION
This PR introduces 2 changes
* When looking for an `OCI_EXE`, check for podman first. Docker users usually only have docker installed. Podman users may link `docker` to `podman` as to not break scripts that have `docker` hard-coded. Alternative: Fail if both are found
* Don't set `USER_IDS` when using podman. Podman is most likely run in rootless mode. If it's not, it's going to be run with `sudo`. In neither of both cases, setting `USER_IDS` (as is done right now) is useful. This fixes #649. Alternative: Allow to manually set `USER_IDS`