### PR TITLE
dockcross-script: Specify --platform flag

### DIFF
--- a/imagefiles/dockcross.sh
+++ b/imagefiles/dockcross.sh
@@ -242,6 +242,7 @@ TTY_ARGS=
 tty -s && [ -z "$MSYS" ] && TTY_ARGS=-ti
 CONTAINER_NAME=dockcross_$RANDOM
 $OCI_EXE run $TTY_ARGS --name $CONTAINER_NAME \
+    --platform linux/amd64 \
     -v "$HOST_PWD":/work \
     $HOST_VOLUMES \
     "${USER_IDS[@]}" \


### PR DESCRIPTION
All images built for a linux/amd64 host.

Addresses warning when running an Apple M1:

  WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
