### PR TITLE
Update android ndk to r25b and api to 33

### DIFF
--- a/android-arm/Dockerfile.in
+++ b/android-arm/Dockerfile.in
@@ -16,8 +16,8 @@ ENV AS=${CROSS_ROOT}/bin/llvm-as \
     CXX=${CROSS_ROOT}/bin/clang++ \
     LD=${CROSS_ROOT}/bin/ld
 
-ENV ANDROID_NDK_REVISION 23
-ENV ANDROID_NDK_API 23
+ENV ANDROID_NDK_REVISION 25b
+ENV ANDROID_API 33
 
 RUN mkdir -p /build && \
     cd /build && \
@@ -26,7 +26,7 @@ RUN mkdir -p /build && \
     cd android-ndk-r${ANDROID_NDK_REVISION} && \
     ./build/tools/make_standalone_toolchain.py \
       --arch arm \
-      --api ${ANDROID_NDK_API} \
+      --api ${ANDROID_API} \
       --stl=libc++ \
       --install-dir=${CROSS_ROOT} && \
     cd / && \

--- a/android-arm64/Dockerfile.in
+++ b/android-arm64/Dockerfile.in
@@ -20,8 +20,8 @@ ENV AS=${CROSS_ROOT}/bin/llvm-as \
     CXX=${CROSS_ROOT}/bin/clang++ \
     LD=${CROSS_ROOT}/bin/ld
 
-ENV ANDROID_NDK_REVISION 23
-ENV ANDROID_NDK_API 23
+ENV ANDROID_NDK_REVISION 25b
+ENV ANDROID_API 33
 
 RUN mkdir -p /build && \
     cd /build && \
@@ -30,7 +30,7 @@ RUN mkdir -p /build && \
     cd android-ndk-r${ANDROID_NDK_REVISION} && \
     ./build/tools/make_standalone_toolchain.py \
       --arch arm64 \
-      --api ${ANDROID_NDK_API} \
+      --api ${ANDROID_API} \
       --stl=libc++ \
       --install-dir=${CROSS_ROOT} && \
     cd / && \

--- a/android-x86/Dockerfile
+++ b/android-x86/Dockerfile
@@ -11,8 +11,8 @@ ENV AS=${CROSS_ROOT}/bin/llvm-as \
     CXX=${CROSS_ROOT}/bin/clang++ \
     LD=${CROSS_ROOT}/bin/ld
 
-ENV ANDROID_NDK_REVISION 23
-ENV ANDROID_NDK_API 23
+ENV ANDROID_NDK_REVISION 25b
+ENV ANDROID_API 33
 
 RUN mkdir -p /build && \
     cd /build && \
@@ -21,7 +21,7 @@ RUN mkdir -p /build && \
     cd android-ndk-r${ANDROID_NDK_REVISION} && \
     ./build/tools/make_standalone_toolchain.py \
       --arch x86 \
-      --api ${ANDROID_NDK_API} \
+      --api ${ANDROID_API} \
       --stl=libc++ \
       --install-dir=${CROSS_ROOT} && \
     cd / && \

--- a/android-x86_64/Dockerfile
+++ b/android-x86_64/Dockerfile
@@ -11,8 +11,8 @@ ENV AS=${CROSS_ROOT}/bin/llvm-as \
     CXX=${CROSS_ROOT}/bin/clang++ \
     LD=${CROSS_ROOT}/bin/ld
 
-ENV ANDROID_NDK_REVISION 23
-ENV ANDROID_NDK_API 23
+ENV ANDROID_NDK_REVISION 25b
+ENV ANDROID_API 33
 
 RUN mkdir -p /build && \
     cd /build && \
@@ -21,7 +21,7 @@ RUN mkdir -p /build && \
     cd android-ndk-r${ANDROID_NDK_REVISION} && \
     ./build/tools/make_standalone_toolchain.py \
       --arch x86_64 \
-      --api ${ANDROID_NDK_API} \
+      --api ${ANDROID_API} \
       --stl=libc++ \
       --install-dir=${CROSS_ROOT} && \
     cd / && \


### PR DESCRIPTION
I always tend to forget, but there is no reason to keep the api to an old version, is there?

Also I renamed ANDROID_NDK_API to ANDROID_API because it seems to me that this is what it is.