### PR TITLE
Set Android ndk api back to 23 (Android 6.0)

### DIFF
--- a/android-arm/Dockerfile.in
+++ b/android-arm/Dockerfile.in
@@ -17,7 +17,7 @@ ENV AS=${CROSS_ROOT}/bin/llvm-as \
     LD=${CROSS_ROOT}/bin/ld
 
 ENV ANDROID_NDK_REVISION 25b
-ENV ANDROID_API 33
+ENV ANDROID_API 23
 
 RUN mkdir -p /build && \
     cd /build && \

--- a/android-arm64/Dockerfile.in
+++ b/android-arm64/Dockerfile.in
@@ -21,7 +21,7 @@ ENV AS=${CROSS_ROOT}/bin/llvm-as \
     LD=${CROSS_ROOT}/bin/ld
 
 ENV ANDROID_NDK_REVISION 25b
-ENV ANDROID_API 33
+ENV ANDROID_API 23
 
 RUN mkdir -p /build && \
     cd /build && \

--- a/android-x86/Dockerfile
+++ b/android-x86/Dockerfile
@@ -12,7 +12,7 @@ ENV AS=${CROSS_ROOT}/bin/llvm-as \
     LD=${CROSS_ROOT}/bin/ld
 
 ENV ANDROID_NDK_REVISION 25b
-ENV ANDROID_API 33
+ENV ANDROID_API 23
 
 RUN mkdir -p /build && \
     cd /build && \

--- a/android-x86_64/Dockerfile
+++ b/android-x86_64/Dockerfile
@@ -12,7 +12,7 @@ ENV AS=${CROSS_ROOT}/bin/llvm-as \
     LD=${CROSS_ROOT}/bin/ld
 
 ENV ANDROID_NDK_REVISION 25b
-ENV ANDROID_API 33
+ENV ANDROID_API 23
 
 RUN mkdir -p /build && \
     cd /build && \


### PR DESCRIPTION
I finally found an answer to my question [here](https://developer.android.com/ndk/guides/common-problems#minsdkversion_set_higher_than_device_api_level):

> Problem: Your NDK API level is higher than the API supported by your device.
>
> Solution: Set your NDK API level (APP_PLATFORM) to the minimum version of Android your app supports.

So the API level, for NDK, is "the minimum version of Android the app supports". So it makes sense for dockcross to keep it low. API 23 is Android 6, which seems reasonable. That's also what it was before I updated the NDK a couple weeks ago.

Sorry about that, at least now I know how this number is meant to be used :innocent:!