### PR TITLE
Added linux/aarch64 platform to build commands

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,29 +24,23 @@ jobs:
           submodules: "recursive"
           fetch-depth: 1
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: create buildx
+        run: docker buildx create --name mybuilder --use
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+
       - name: build
         run: make base
 
       - name: test
         run: make base.test
-
-      - name: archive base
-        run: |
-          mkdir -p cache
-          docker save dockcross/base:latest | xz -e9 -T0 > ./cache/base.tar.xz
-
-      - name: save base
-        uses: actions/upload-artifact@v3
-        with:
-          name: cache
-          path: ./cache
-          retention-days: 1
-
-      - name: deploy
-        if: github.ref == 'refs/heads/master'
-        run: |
-            docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASS }}
-            docker image push dockcross/base --all-tags
 
   image:
     name: ${{ matrix.arch_name.image }}
@@ -1021,13 +1015,17 @@ jobs:
           submodules: "recursive"
           fetch-depth: 1
 
-      - uses: actions/download-artifact@v3
-        with:
-          name: cache
-          path: ./cache
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
-      - name: load base
-        run: xz -d -k < ./cache/base.tar.xz | docker load
+      - name: create buildx
+        run: docker buildx create --name mybuilder --use
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
 
       - name: build
         run: make ${{ matrix.arch_name.image }}
@@ -1149,8 +1147,4 @@ jobs:
           cd ..
           rm -rf libopencm3
 
-      - name: deploy
-        if: github.ref == 'refs/heads/master'
-        run: |
-            docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASS }}
-            docker image push dockcross/${{ matrix.arch_name.image }} --all-tags
+

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ ORG = dockcross
 # Directory where to generate the dockcross script for each images (e.g bin/dockcross-manylinux2014-x64)
 BIN = ./bin
 
+# Supported platforms: images are generated for each platform in the list
+GEN_PLATFORMS = linux/amd64,linux/arm64
+
 # These images are built using the "build implicit rule"
 STANDARD_IMAGES = android-arm android-arm64 android-x86 android-x86_64 \
 	linux-i686 linux-x86 linux-x64 linux-x64-clang linux-arm64 linux-arm64-musl linux-arm64-full \
@@ -116,15 +119,15 @@ $(GEN_IMAGE_DOCKERFILES) Dockerfile: %Dockerfile: %Dockerfile.in $(DOCKER_COMPOS
 web-wasm: web-wasm/Dockerfile
 	mkdir -p $@/imagefiles && cp -r imagefiles $@/
 	cp -r test web-wasm/
-	$(DOCKER) build -t $(ORG)/web-wasm:$(TAG) \
+	$(DOCKER) buildx build -t $(ORG)/web-wasm:$(TAG) \
 		-t $(ORG)/web-wasm:latest \
-		--platform linux/amd64 \
-		--platform linux/arm64/v8 \
+		--platform $(GEN_PLATFORMS) \
 		--build-arg IMAGE=$(ORG)/web-wasm \
 		--build-arg VERSION=$(TAG) \
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \
 		--build-arg VCS_URL=`git config --get remote.origin.url` \
 		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+		--push \
 		web-wasm
 	rm -rf web-wasm/test
 	rm -rf $@/imagefiles
@@ -144,16 +147,16 @@ manylinux2014-aarch64: manylinux2014-aarch64/Dockerfile
 	@# Get libstdc++ from quay.io/pypa/manylinux2014_aarch64 container
 	docker run -v `pwd`:/host --rm -e LIB_PATH=/host/$@/xc_script/ quay.io/pypa/manylinux2014_aarch64 bash -c "PASS=1 /host/$@/xc_script/docker_setup_scrpits/copy_libstd.sh"
 	mkdir -p $@/imagefiles && cp -r imagefiles $@/
-	$(DOCKER) build -t $(ORG)/manylinux2014-aarch64:$(TAG) \
+	$(DOCKER) buildx build -t $(ORG)/manylinux2014-aarch64:$(TAG) \
 		-t $(ORG)/manylinux2014-aarch64:latest \
-		--platform linux/amd64 \
-		--platform linux/arm64/v8 \
+		--platform $(GEN_PLATFORMS) \
 		--build-arg IMAGE=$(ORG)/manylinux2014-aarch64 \
 		--build-arg VERSION=$(TAG) \
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \
 		--build-arg VCS_URL=`git config --get remote.origin.url` \
 		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
-		-f manylinux2014-aarch64/Dockerfile .
+		-f manylinux2014-aarch64/Dockerfile \
+		--push .
 	rm -rf $@/imagefiles
 	@# libstdc++ is coppied into image, now remove it
 	docker run -v `pwd`:/host --rm quay.io/pypa/manylinux2014_aarch64 bash -c "rm -rf /host/$@/xc_script/usr"
@@ -168,16 +171,16 @@ manylinux2014-aarch64.test: manylinux2014-aarch64
 #
 manylinux_2_28-x64: manylinux_2_28-x64/Dockerfile
 	mkdir -p $@/imagefiles && cp -r imagefiles $@/
-	$(DOCKER) build -t $(ORG)/manylinux_2_28-x64:$(TAG) \
+	$(DOCKER) buildx build -t $(ORG)/manylinux_2_28-x64:$(TAG) \
 		-t $(ORG)/manylinux_2_28-x64:latest \
-		--platform linux/amd64 \
-		--platform linux/arm64/v8 \
+		--platform $(GEN_PLATFORMS) \
 		--build-arg IMAGE=$(ORG)/manylinux_2_28-x64 \
 		--build-arg VERSION=$(TAG) \
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \
 		--build-arg VCS_URL=`git config --get remote.origin.url` \
 		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
-		-f manylinux_2_28-x64/Dockerfile .
+		-f manylinux_2_28-x64/Dockerfile \
+		--push .
 	rm -rf $@/imagefiles
 
 manylinux_2_28-x64.test: manylinux_2_28-x64
@@ -190,16 +193,16 @@ manylinux_2_28-x64.test: manylinux_2_28-x64
 #
 manylinux2014-x64: manylinux2014-x64/Dockerfile
 	mkdir -p $@/imagefiles && cp -r imagefiles $@/
-	$(DOCKER) build -t $(ORG)/manylinux2014-x64:$(TAG) \
+	$(DOCKER) buildx build -t $(ORG)/manylinux2014-x64:$(TAG) \
 		-t $(ORG)/manylinux2014-x64:latest \
-		--platform linux/amd64 \
-		--platform linux/arm64/v8 \
+		--platform $(GEN_PLATFORMS) \
 		--build-arg IMAGE=$(ORG)/manylinux2014-x64 \
 		--build-arg VERSION=$(TAG) \
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \
 		--build-arg VCS_URL=`git config --get remote.origin.url` \
 		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
-		-f manylinux2014-x64/Dockerfile .
+		-f manylinux2014-x64/Dockerfile \
+		--push .
 	rm -rf $@/imagefiles
 
 manylinux2014-x64.test: manylinux2014-x64
@@ -212,16 +215,16 @@ manylinux2014-x64.test: manylinux2014-x64
 #
 manylinux2014-x86: manylinux2014-x86/Dockerfile
 	mkdir -p $@/imagefiles && cp -r imagefiles $@/
-	$(DOCKER) build -t $(ORG)/manylinux2014-x86:$(TAG) \
+	$(DOCKER) buildx build -t $(ORG)/manylinux2014-x86:$(TAG) \
 		-t $(ORG)/manylinux2014-x86:latest \
-		--platform linux/amd64 \
-		--platform linux/arm64/v8 \
+		--platform $(GEN_PLATFORMS) \
 		--build-arg IMAGE=$(ORG)/manylinux2014-x86 \
 		--build-arg VERSION=$(TAG) \
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \
 		--build-arg VCS_URL=`git config --get remote.origin.url` \
 		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
-		-f manylinux2014-x86/Dockerfile .
+		-f manylinux2014-x86/Dockerfile \
+		--push .
 	rm -rf $@/imagefiles
 
 manylinux2014-x86.test: manylinux2014-x86
@@ -233,12 +236,12 @@ manylinux2014-x86.test: manylinux2014-x86
 # base
 #
 base: Dockerfile imagefiles/
-	$(DOCKER) build -t $(ORG)/base:latest \
+	$(DOCKER) buildx build -t $(ORG)/base:latest \
 		-t $(ORG)/base:$(TAG) \
-		--platform linux/amd64 \
-		--platform linux/arm64/v8 \
+		--platform $(GEN_PLATFORMS) \
 		--build-arg IMAGE=$(ORG)/base \
 		--build-arg VCS_URL=`git config --get remote.origin.url` \
+		--push \
 		.
 
 base.test: base
@@ -257,15 +260,15 @@ $(VERBOSE).SILENT: display_images
 
 $(STANDARD_IMAGES): %: %/Dockerfile base
 	mkdir -p $@/imagefiles && cp -r imagefiles $@/
-	$(DOCKER) build -t $(ORG)/$@:latest \
+	$(DOCKER) buildx build -t $(ORG)/$@:latest \
 		-t $(ORG)/$@:$(TAG) \
-		--platform linux/amd64 \
-		--platform linux/arm64/v8 \
+		--platform $(GEN_PLATFORMS) \
 		--build-arg IMAGE=$(ORG)/$@ \
 		--build-arg VERSION=$(TAG) \
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \
 		--build-arg VCS_URL=`git config --get remote.origin.url` \
 		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+		--push \
 		$@
 	rm -rf $@/imagefiles
 

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ web-wasm: web-wasm/Dockerfile
 	cp -r test web-wasm/
 	$(DOCKER) build -t $(ORG)/web-wasm:$(TAG) \
 		-t $(ORG)/web-wasm:latest \
+		--platform linux/amd64,linux/arm64/v8 \
 		--build-arg IMAGE=$(ORG)/web-wasm \
 		--build-arg VERSION=$(TAG) \
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \
@@ -144,6 +145,7 @@ manylinux2014-aarch64: manylinux2014-aarch64/Dockerfile
 	mkdir -p $@/imagefiles && cp -r imagefiles $@/
 	$(DOCKER) build -t $(ORG)/manylinux2014-aarch64:$(TAG) \
 		-t $(ORG)/manylinux2014-aarch64:latest \
+		--platform linux/amd64,linux/arm64/v8 \
 		--build-arg IMAGE=$(ORG)/manylinux2014-aarch64 \
 		--build-arg VERSION=$(TAG) \
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \
@@ -166,6 +168,7 @@ manylinux_2_28-x64: manylinux_2_28-x64/Dockerfile
 	mkdir -p $@/imagefiles && cp -r imagefiles $@/
 	$(DOCKER) build -t $(ORG)/manylinux_2_28-x64:$(TAG) \
 		-t $(ORG)/manylinux_2_28-x64:latest \
+		--platform linux/amd64,linux/arm64/v8 \
 		--build-arg IMAGE=$(ORG)/manylinux_2_28-x64 \
 		--build-arg VERSION=$(TAG) \
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \
@@ -186,6 +189,7 @@ manylinux2014-x64: manylinux2014-x64/Dockerfile
 	mkdir -p $@/imagefiles && cp -r imagefiles $@/
 	$(DOCKER) build -t $(ORG)/manylinux2014-x64:$(TAG) \
 		-t $(ORG)/manylinux2014-x64:latest \
+		--platform linux/amd64,linux/arm64/v8 \
 		--build-arg IMAGE=$(ORG)/manylinux2014-x64 \
 		--build-arg VERSION=$(TAG) \
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \
@@ -206,6 +210,7 @@ manylinux2014-x86: manylinux2014-x86/Dockerfile
 	mkdir -p $@/imagefiles && cp -r imagefiles $@/
 	$(DOCKER) build -t $(ORG)/manylinux2014-x86:$(TAG) \
 		-t $(ORG)/manylinux2014-x86:latest \
+		--platform linux/amd64,linux/arm64/v8 \
 		--build-arg IMAGE=$(ORG)/manylinux2014-x86 \
 		--build-arg VERSION=$(TAG) \
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \
@@ -225,6 +230,7 @@ manylinux2014-x86.test: manylinux2014-x86
 base: Dockerfile imagefiles/
 	$(DOCKER) build -t $(ORG)/base:latest \
 		-t $(ORG)/base:$(TAG) \
+		--platform linux/amd64,linux/arm64/v8 \
 		--build-arg IMAGE=$(ORG)/base \
 		--build-arg VCS_URL=`git config --get remote.origin.url` \
 		.
@@ -247,6 +253,7 @@ $(STANDARD_IMAGES): %: %/Dockerfile base
 	mkdir -p $@/imagefiles && cp -r imagefiles $@/
 	$(DOCKER) build -t $(ORG)/$@:latest \
 		-t $(ORG)/$@:$(TAG) \
+		--platform linux/amd64,linux/arm64/v8 \
 		--build-arg IMAGE=$(ORG)/$@ \
 		--build-arg VERSION=$(TAG) \
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,8 @@ web-wasm: web-wasm/Dockerfile
 	cp -r test web-wasm/
 	$(DOCKER) build -t $(ORG)/web-wasm:$(TAG) \
 		-t $(ORG)/web-wasm:latest \
-		--platform linux/amd64,linux/arm64/v8 \
+		--platform linux/amd64 \
+		--platform linux/arm64/v8 \
 		--build-arg IMAGE=$(ORG)/web-wasm \
 		--build-arg VERSION=$(TAG) \
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \
@@ -145,7 +146,8 @@ manylinux2014-aarch64: manylinux2014-aarch64/Dockerfile
 	mkdir -p $@/imagefiles && cp -r imagefiles $@/
 	$(DOCKER) build -t $(ORG)/manylinux2014-aarch64:$(TAG) \
 		-t $(ORG)/manylinux2014-aarch64:latest \
-		--platform linux/amd64,linux/arm64/v8 \
+		--platform linux/amd64 \
+		--platform linux/arm64/v8 \
 		--build-arg IMAGE=$(ORG)/manylinux2014-aarch64 \
 		--build-arg VERSION=$(TAG) \
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \
@@ -168,7 +170,8 @@ manylinux_2_28-x64: manylinux_2_28-x64/Dockerfile
 	mkdir -p $@/imagefiles && cp -r imagefiles $@/
 	$(DOCKER) build -t $(ORG)/manylinux_2_28-x64:$(TAG) \
 		-t $(ORG)/manylinux_2_28-x64:latest \
-		--platform linux/amd64,linux/arm64/v8 \
+		--platform linux/amd64 \
+		--platform linux/arm64/v8 \
 		--build-arg IMAGE=$(ORG)/manylinux_2_28-x64 \
 		--build-arg VERSION=$(TAG) \
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \
@@ -189,7 +192,8 @@ manylinux2014-x64: manylinux2014-x64/Dockerfile
 	mkdir -p $@/imagefiles && cp -r imagefiles $@/
 	$(DOCKER) build -t $(ORG)/manylinux2014-x64:$(TAG) \
 		-t $(ORG)/manylinux2014-x64:latest \
-		--platform linux/amd64,linux/arm64/v8 \
+		--platform linux/amd64 \
+		--platform linux/arm64/v8 \
 		--build-arg IMAGE=$(ORG)/manylinux2014-x64 \
 		--build-arg VERSION=$(TAG) \
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \
@@ -210,7 +214,8 @@ manylinux2014-x86: manylinux2014-x86/Dockerfile
 	mkdir -p $@/imagefiles && cp -r imagefiles $@/
 	$(DOCKER) build -t $(ORG)/manylinux2014-x86:$(TAG) \
 		-t $(ORG)/manylinux2014-x86:latest \
-		--platform linux/amd64,linux/arm64/v8 \
+		--platform linux/amd64 \
+		--platform linux/arm64/v8 \
 		--build-arg IMAGE=$(ORG)/manylinux2014-x86 \
 		--build-arg VERSION=$(TAG) \
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \
@@ -230,7 +235,8 @@ manylinux2014-x86.test: manylinux2014-x86
 base: Dockerfile imagefiles/
 	$(DOCKER) build -t $(ORG)/base:latest \
 		-t $(ORG)/base:$(TAG) \
-		--platform linux/amd64,linux/arm64/v8 \
+		--platform linux/amd64 \
+		--platform linux/arm64/v8 \
 		--build-arg IMAGE=$(ORG)/base \
 		--build-arg VCS_URL=`git config --get remote.origin.url` \
 		.
@@ -253,7 +259,8 @@ $(STANDARD_IMAGES): %: %/Dockerfile base
 	mkdir -p $@/imagefiles && cp -r imagefiles $@/
 	$(DOCKER) build -t $(ORG)/$@:latest \
 		-t $(ORG)/$@:$(TAG) \
-		--platform linux/amd64,linux/arm64/v8 \
+		--platform linux/amd64 \
+		--platform linux/arm64/v8 \
 		--build-arg IMAGE=$(ORG)/$@ \
 		--build-arg VERSION=$(TAG) \
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \


### PR DESCRIPTION
The purpose is to have multi-platform images that, once pulled on an Apple Silicon machine, can run at native speed without the need for emulation.
