### PR TITLE
Add NASM package

### DIFF
--- a/common/common.debian
+++ b/common/common.debian
@@ -23,6 +23,7 @@ RUN \
     libncurses5 \
     libtool \
     make \
+    nasm \
     ncurses-dev \
     pkg-config \
     pax \


### PR DESCRIPTION
Netwide assembler is a small package, but when required it is hard to avoid it, e.g. https://github.com/google/tensorstore/issues/65#issuecomment-1324368082.
```log
$ apt show nasm
Package: nasm
Version: 2.15.05-1
Priority: optional
Section: universe/devel
Origin: Ubuntu
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Original-Maintainer: Anibal Monsalve Salazar <anibal@debian.org>
Bugs: https://bugs.launchpad.net/ubuntu/+filebug
Installed-Size: 3,345 kB
Depends: dpkg (>= 1.15.4) | install-info, libc6 (>= 2.14) Homepage: http://www.nasm.us/
Download-Size: 375 kB
APT-Manual-Installed: yes
APT-Sources: http://us.archive.ubuntu.com/ubuntu jammy/universe amd64 Packages Description: General-purpose x86 assembler
 Netwide Assembler.  NASM will currently output flat-form binary files,
 a.out, COFF and ELF Unix object files, and Microsoft 16-bit DOS and
 Win32 object files.
 .
 Also included is NDISASM, a prototype x86 binary-file disassembler
 which uses the same instruction table as NASM.
 .
 NASM is released under the GNU Lesser General Public License (LGPL).
```