### PR TITLE
Docs — Extending dockcross: run apt non-interactively

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ An example Dockerfile would be:
 FROM dockcross/linux-armv7
 
 ENV DEFAULT_DOCKCROSS_IMAGE my_cool_image
-RUN apt-get install nano
+RUN apt-get install -y nano
 ```
 
 And then in the shell:


### PR DESCRIPTION
You need the `-y` (aka `--assume-yes`) flag when running apt in a script otherwise the thing hangs forever waiting for interactive confirmation for some larger downloads.