### PR TITLE
Support for building images locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,8 @@ Then you must create a file named `Dockerfile.in` in the image folder (`linux-ar
 Copy text to `Dockerfile.in` file:
 
 ```docker
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/Makefile
+++ b/Makefile
@@ -247,6 +247,7 @@ $(STANDARD_IMAGES): %: %/Dockerfile base
 	mkdir -p $@/imagefiles && cp -r imagefiles $@/
 	$(DOCKER) build -t $(ORG)/$@:latest \
 		-t $(ORG)/$@:$(TAG) \
+		--build-arg ORG=$(ORG) \
 		--build-arg IMAGE=$(ORG)/$@ \
 		--build-arg VERSION=$(TAG) \
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \

--- a/README.md
+++ b/README.md
@@ -565,6 +565,26 @@ The key difference is that [dockbuild](https://github.com/dockbuild/dockbuild#re
 
 **dockcross** is used to build binaries for many different platforms. **dockcross** performs a cross compilation where the host build system is a Linux x86_64 / amd64 Docker image (so that it can be used for building binaries on any system which can run Docker images) and the target runtime system varies.
 
+## Build images by yourself
+
+Perbuilt images available on Docker hub are single architecture amd64 images. Those images work evan on different architectures: for example, if you run a dockcross image on Docker running on an Apple M1, the image will run in emulation mode, meaning that it will still work as expected, although it will be slower than running on native hardware (you can expect a factor or 10 or more).
+
+To overcome this limitation, you can build your own images on non-amd64 architectures. To do so, you can use the `Makefile` provided in this repository. For example, to build the `linux-armv7` image, and provided that your Docker hub organization name is `ACME`, you can run:
+
+```bash
+$ make ORG=ACME base
+$ make ORG=ACME linux-armv7
+```
+
+This will create the Docker images `ACME/base` and `ACME/linux-armv7`, so that you can later launch a container using the `ACME/linux-armv7` image:
+
+```
+$ docker run --rm ACME/linux-armv7 uname -a
+Linux 89b164ee8d90 5.15.49-linuxkit #1 SMP PREEMPT Tue Sep 13 07:51:32 UTC 2022 aarch64 GNU/Linux
+```
+
+Note that the architecture is now `aarch64` instead of `amd64`, so it runs natively on the Apple M1.
+
 \-\--
 
 Credits:

--- a/android-arm/Dockerfile.in
+++ b/android-arm/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 MAINTAINER Matt McCormick "matt.mccormick@kitware.com"
 
 # The cross-compiling emulator

--- a/android-arm64/Dockerfile.in
+++ b/android-arm64/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 MAINTAINER Matt McCormick "matt.mccormick@kitware.com"
 RUN \
   sed -i '/debian-security/d' /etc/apt/sources.list && \

--- a/bare-armv7emhf-nano_newlib/Dockerfile.in
+++ b/bare-armv7emhf-nano_newlib/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Chen Tao t.clydechen@gmail.com"
 

--- a/linux-arm64-full/Dockerfile.in
+++ b/linux-arm64-full/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/linux-arm64-lts/Dockerfile.in
+++ b/linux-arm64-lts/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 # This is for 64-bit ARM Linux machine (Ubuntu 18.04 or Debian 9 mini)
 

--- a/linux-arm64-musl/Dockerfile.in
+++ b/linux-arm64-musl/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 ENV XCC_PREFIX /usr/xcc
 ENV CROSS_TRIPLE aarch64-linux-musl

--- a/linux-arm64/Dockerfile.in
+++ b/linux-arm64/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/linux-armv5-musl/Dockerfile.in
+++ b/linux-armv5-musl/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/linux-armv5-uclibc/Dockerfile.in
+++ b/linux-armv5-uclibc/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/linux-armv5/Dockerfile.in
+++ b/linux-armv5/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/linux-armv6-lts/Dockerfile.in
+++ b/linux-armv6-lts/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/linux-armv6-musl/Dockerfile.in
+++ b/linux-armv6-musl/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 ENV XCC_PREFIX /usr/xcc
 ENV CROSS_TRIPLE armv6-linux-musleabihf

--- a/linux-armv6/Dockerfile.in
+++ b/linux-armv6/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/linux-armv7-lts/Dockerfile.in
+++ b/linux-armv7-lts/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/linux-armv7/Dockerfile.in
+++ b/linux-armv7/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/linux-armv7a-lts/Dockerfile.in
+++ b/linux-armv7a-lts/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/linux-armv7a/Dockerfile.in
+++ b/linux-armv7a/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/linux-armv7l-musl/Dockerfile.in
+++ b/linux-armv7l-musl/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 ENV XCC_PREFIX /usr/xcc
 ENV CROSS_TRIPLE armv7l-linux-musleabihf

--- a/linux-i686/Dockerfile.in
+++ b/linux-i686/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="PJ Reid PJ.Reid@Zetier.com"
 

--- a/linux-m68k-uclibc/Dockerfile.in
+++ b/linux-m68k-uclibc/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/linux-mips-lts/Dockerfile.in
+++ b/linux-mips-lts/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/linux-mips/Dockerfile.in
+++ b/linux-mips/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/linux-mipsel-lts/Dockerfile.in
+++ b/linux-mipsel-lts/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/linux-ppc64le/Dockerfile.in
+++ b/linux-ppc64le/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/linux-riscv32/Dockerfile.in
+++ b/linux-riscv32/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/linux-riscv64/Dockerfile.in
+++ b/linux-riscv64/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/linux-s390x/Dockerfile.in
+++ b/linux-s390x/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/linux-x64-clang/Dockerfile.in
+++ b/linux-x64-clang/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/linux-x64-tinycc/Dockerfile.in
+++ b/linux-x64-tinycc/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/linux-x64/Dockerfile.in
+++ b/linux-x64/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/linux-x86/Dockerfile.in
+++ b/linux-x86/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/linux-x86_64-full/Dockerfile.in
+++ b/linux-x86_64-full/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/linux-xtensa-uclibc/Dockerfile.in
+++ b/linux-xtensa-uclibc/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/web-wasi/Dockerfile.in
+++ b/web-wasi/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/windows-arm64/Dockerfile.in
+++ b/windows-arm64/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/windows-armv7/Dockerfile.in
+++ b/windows-armv7/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/windows-shared-x64-posix/Dockerfile.in
+++ b/windows-shared-x64-posix/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/windows-shared-x64/Dockerfile.in
+++ b/windows-shared-x64/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/windows-shared-x86/Dockerfile.in
+++ b/windows-shared-x86/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/windows-static-x64-posix/Dockerfile.in
+++ b/windows-static-x64-posix/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/windows-static-x64/Dockerfile.in
+++ b/windows-static-x64/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/windows-static-x86/Dockerfile.in
+++ b/windows-static-x86/Dockerfile.in
@@ -1,4 +1,5 @@
-FROM dockcross/base:latest
+ARG ORG=dockcross
+FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 


### PR DESCRIPTION
This set of changes allows to build images locally like this:

```
$ make ORG=ACME base
$ make ORG=ACME linux-armv7
```

The default of the `ORG` variable is of course `dockcross`, so nothing changes on standard CI. This change only affects images built on top of `dockcross/base`, and it **does not** affect `manylinux*` nor `web-was*` images.

This way, custom images can be built on different architectures (notably Apple Silicon). This is a kind of shortcut while I am working on creating multiplatform images with the current dockcross CI scheme.