### PR TITLE
Removed platform specification in dockcross.sh

### DIFF
--- a/imagefiles/dockcross.sh
+++ b/imagefiles/dockcross.sh
@@ -242,7 +242,6 @@ TTY_ARGS=
 tty -s && [ -z "$MSYS" ] && TTY_ARGS=-ti
 CONTAINER_NAME=dockcross_$RANDOM
 $OCI_EXE run $TTY_ARGS --name $CONTAINER_NAME \
-    --platform linux/amd64 \
     -v "$HOST_PWD":/work \
     $HOST_VOLUMES \
     "${USER_IDS[@]}" \


### PR DESCRIPTION
Ditto. 
With that specification in place, a locally built image on architectures != amd64 would fail to execute the `dockcross.sh` script and try to pull a non-existing amd64 image from docker.io repository under the custom organisation name.
That specification shall be anyway superfluous, unless one really wants to run an emulated image even if the native image is available.