### PR TITLE
web-wasi: Bump to WASI-SDK 17

### DIFF
--- a/web-wasi/Dockerfile.in
+++ b/web-wasi/Dockerfile.in
@@ -3,24 +3,48 @@ FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 
-ENV WASI_VERSION 16
+ENV WASI_VERSION 17
 ENV WASI_VERSION_FULL ${WASI_VERSION}.0
 RUN cd /usr/ && \
   curl -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_VERSION}/wasi-sdk-${WASI_VERSION_FULL}-linux.tar.gz && \
   tar xvzf wasi-sdk-${WASI_VERSION_FULL}-linux.tar.gz && \
   rm wasi-sdk-${WASI_VERSION_FULL}-linux.tar.gz
+ENV WASI_SYSROOT /usr/wasi-sdk-${WASI_VERSION_FULL}/share/wasi-sysroot
 ENV WASI_SDK_PATH /usr/wasi-sdk-${WASI_VERSION_FULL}
-ENV WASI_SYSROOT ${WASI_SDK_PATH}/share/wasi-sysroot
+
+ENV LLVM_VERSION 15
+
+# Build LLVM / Clang that supports our glibc
+RUN apt-get update && \
+    # Temporarily install to setup apt repositories
+    apt-get install -y && \
+\
+    curl -sS https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /etc/apt/trusted.gpg.d/llvm.gpg && \
+    echo "deb [signed-by=/etc/apt/trusted.gpg.d/llvm.gpg] http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-${LLVM_VERSION} main" >> /etc/apt/sources.list.d/llvm.list && \
+    echo "deb-src [signed-by=/etc/apt/trusted.gpg.d/llvm.gpg] http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-${LLVM_VERSION} main" >> /etc/apt/sources.list.d/llvm.list && \
+\
+    apt-get update && \
+    apt-get install -y clang-${LLVM_VERSION} lld-${LLVM_VERSION} && \
+    rm -rf /var/lib/apt/lists/*
+
+# The path to the rt directory contains the LLVM patch version which is not reflected in the LLVM apt repository
+# or package. To make adding the RT robust to changing patch versions without needing to duplicate the folder
+# content, we copy after extracting using a bash glob to resolve the patch version
+RUN cd /usr/ && \
+  curl -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_VERSION}/libclang_rt.builtins-wasm32-wasi-${WASI_VERSION_FULL}.tar.gz && \
+  tar xvzf libclang_rt.builtins-wasm32-wasi-${WASI_VERSION_FULL}.tar.gz && \
+  rm libclang_rt.builtins-wasm32-wasi-${WASI_VERSION_FULL}.tar.gz && \
+  cp -a /usr/lib/wasi/* $(echo /usr/lib/llvm-${LLVM_VERSION}/lib/clang/${LLVM_VERSION}.*)/lib/wasi/
 
 COPY clang-wasi-sysroot.sh clang++-wasi-sysroot.sh /usr/local/bin/
 
 ENV CROSS_TRIPLE=wasm32-wasi
 ENV CROSS_ROOT=${WASI_SDK_PATH}
-ENV ANDROID_NDK=${CROSS_ROOT}
-ENV AR=${CROSS_ROOT}/bin/llvm-ar \
+ENV AR=llvm-ar-${LLVM_VERSION} \
     CC=clang-wasi-sysroot.sh \
     CXX=clang++-wasi-sysroot.sh \
-    LD=${CROSS_ROOT}/bin/wasm-ld
+    LD=wasm-ld-${LLVM_VERSION} \
+    RANLIB=llvm-ranlib-${LLVM_VERSION}
 
 #include "common.webassembly"
 

--- a/web-wasi/Toolchain.cmake
+++ b/web-wasi/Toolchain.cmake
@@ -6,5 +6,7 @@ set(CMAKE_SYSROOT $ENV{WASI_SYSROOT})
 
 set(CMAKE_C_COMPILER /usr/local/bin/clang-wasi-sysroot.sh)
 set(CMAKE_CXX_COMPILER /usr/local/bin/clang++-wasi-sysroot.sh)
+set(CMAKE_AR llvm-ar-$ENV{LLVM_VERSION})
+set(CMAKE_RANLIB llvm-ranlib-$ENV{LLVM_VERSION})
 
 set(CMAKE_CROSSCOMPILING_EMULATOR /wasi-runtimes/wasmtime/bin/wasmtime-pwd.sh)

--- a/web-wasi/clang++-wasi-sysroot.sh
+++ b/web-wasi/clang++-wasi-sysroot.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-exec ${WASI_SDK_PATH}/bin/clang++ --sysroot=${WASI_SYSROOT} "$@"
+exec clang++-${LLVM_VERSION} --target=wasm32-wasi --sysroot=${WASI_SYSROOT} "$@"

--- a/web-wasi/clang-wasi-sysroot.sh
+++ b/web-wasi/clang-wasi-sysroot.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-exec ${WASI_SDK_PATH}/bin/clang --sysroot=${WASI_SYSROOT} "$@"
+exec clang-${LLVM_VERSION} --target=wasm32-wasi --sysroot=${WASI_SYSROOT} "$@"


### PR DESCRIPTION
The binary linux SDK in version 17 requires a newer glibc than we have
available, so we have to use our own patched clang. This follows the
approach in:

  https://github.com/WebAssembly/wasi-sdk/pull/271
