### PR TITLE
base: Remove ssh keys

### DIFF
--- a/common/common.debian
+++ b/common/common.debian
@@ -41,4 +41,5 @@ RUN \
     python-is-python3 \
     && apt-get clean autoclean --yes \
     && apt-get autoremove --yes \
-    && rm -rf /var/lib/{apt,dpkg,cache,log}/
+    && rm -rf /var/lib/{apt,dpkg,cache,log}/ \
+    && rm /etc/ssh/*key*


### PR DESCRIPTION
These get installed via the openssh-server package, which is pulled in as a dependency. Remove them before completing the layer to avoid inadvertent usage in these public docker images.