### PR TITLE
Add meson to all images

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Cross compiling toolchains in Docker images.
 - Commands in the container are run as the calling user, so that any created files have the expected ownership, (i.e. not root).
 - Make variables **CC**, **CXX**, **LD**, **AS** etc) are set to point to the appropriate tools in the container.
 - Recent [CMake](https://cmake.org) and ninja are precompiled.
+- [Meson](https://mesonbuild.com) is pre-installed.
 - [Conan.io](https://www.conan.io) can be used as a package manager.
 - Toolchain files configured for CMake.
 - Current directory is mounted as the container\'s workdir, `/work`.

--- a/imagefiles/install-python-packages.sh
+++ b/imagefiles/install-python-packages.sh
@@ -27,6 +27,6 @@ ${PYTHON} get-pip.py --ignore-installed
 rm get-pip.py
 
 ${PYTHON} -m pip install --upgrade --ignore-installed setuptools
-${PYTHON} -m pip install --ignore-installed conan
+${PYTHON} -m pip install --ignore-installed conan meson
 # Purge cache to save space: https://stackoverflow.com/questions/37513597/is-it-safe-to-delete-cache-pip-directory
 ${PYTHON} -m pip cache purge


### PR DESCRIPTION
It was requested [here](https://github.com/dockcross/dockcross/issues/139), and I recently had a need for Meson. I tried it in my custom image by just adding `RUN sudo pip install meson` at the end of an image, but I figure this should work if it works with conan :nerd_face:.

Anyway I mostly want your opinion on that. Just meson needs to be installed and can then be used to (cross-)compile. We could provide default cross files (equivalent of the cmake toolchain files), but the user *must* explicitly call them with `--cross-file`, so it feels like a reasonable first step to just install Meson.

EDIT: I ran `make android-arm64` from scratch (locally), then verified that `meson --version` returns 1.0.0 in the image. So it seems to be working as far as I can tell :+1: 