### PR TITLE
manylinux2014-aarch64: Bump to GCC 10

### DIFF
--- a/manylinux2014-aarch64/crosstool-ng.config
+++ b/manylinux2014-aarch64/crosstool-ng.config
@@ -7,7 +7,9 @@ CT_CONFIGURE_has_cxx11=y
 CT_CONFIGURE_has_wget=y
 CT_CONFIGURE_has_curl=y
 CT_CONFIGURE_has_ninja=y
+CT_CONFIGURE_has_rsync=y
 CT_CONFIGURE_has_make_3_81_or_newer=y
+CT_CONFIGURE_has_make_4_0_or_newer=y
 CT_CONFIGURE_has_libtool_2_4_or_newer=y
 CT_CONFIGURE_has_libtoolize_2_4_or_newer=y
 CT_CONFIGURE_has_autoconf_2_65_or_newer=y
@@ -252,6 +254,18 @@ CT_LINUX_PKG_NAME="linux"
 CT_LINUX_SRC_RELEASE=y
 # CT_LINUX_SRC_DEVEL is not set
 CT_LINUX_PATCH_ORDER="global"
+# CT_LINUX_V_5_16 is not set
+# CT_LINUX_V_5_15 is not set
+# CT_LINUX_V_5_14 is not set
+# CT_LINUX_V_5_13 is not set
+# CT_LINUX_V_5_12 is not set
+# CT_LINUX_V_5_11 is not set
+# CT_LINUX_V_5_10 is not set
+# CT_LINUX_V_5_9 is not set
+# CT_LINUX_V_5_8 is not set
+# CT_LINUX_V_5_7 is not set
+# CT_LINUX_V_5_4 is not set
+# CT_LINUX_V_5_3 is not set
 # CT_LINUX_V_5_2 is not set
 # CT_LINUX_V_5_1 is not set
 # CT_LINUX_V_5_0 is not set
@@ -283,7 +297,6 @@ CT_LINUX_5_12_or_older=y
 CT_LINUX_older_than_5_12=y
 CT_LINUX_5_3_or_older=y
 CT_LINUX_older_than_5_3=y
-CT_LINUX_REQUIRE_older_than_5_3=y
 CT_LINUX_later_than_4_8=y
 CT_LINUX_4_8_or_later=y
 CT_LINUX_later_than_3_7=y
@@ -292,10 +305,6 @@ CT_LINUX_REQUIRE_3_7_or_later=y
 CT_LINUX_later_than_3_2=y
 CT_LINUX_3_2_or_later=y
 CT_KERNEL_DEP_RSYNC=y
-
-#
-# Linux >=5.3 requires rsync
-#
 CT_KERNEL_LINUX_VERBOSITY_0=y
 # CT_KERNEL_LINUX_VERBOSITY_1 is not set
 # CT_KERNEL_LINUX_VERBOSITY_2 is not set
@@ -505,14 +514,14 @@ CT_GCC_SRC_RELEASE=y
 # CT_GCC_SRC_DEVEL is not set
 CT_GCC_PATCH_ORDER="global"
 # CT_GCC_V_11 is not set
-# CT_GCC_V_10 is not set
+CT_GCC_V_10=y
 # CT_GCC_V_9 is not set
-CT_GCC_V_8=y
+# CT_GCC_V_8 is not set
 # CT_GCC_V_7 is not set
 # CT_GCC_V_6 is not set
 # CT_GCC_V_5 is not set
 # CT_GCC_V_4_9 is not set
-CT_GCC_VERSION="8.5.0"
+CT_GCC_VERSION="10.3.0"
 CT_GCC_MIRRORS="$(CT_Mirrors GNU gcc/gcc-${CT_GCC_VERSION}) $(CT_Mirrors sourceware gcc/releases/gcc-${CT_GCC_VERSION})"
 CT_GCC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_GCC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
@@ -520,10 +529,10 @@ CT_GCC_ARCHIVE_FORMATS=".tar.xz .tar.gz"
 CT_GCC_SIGNATURE_FORMAT=""
 CT_GCC_11_or_older=y
 CT_GCC_older_than_11=y
-CT_GCC_10_or_older=y
-CT_GCC_older_than_10=y
-CT_GCC_9_or_older=y
-CT_GCC_older_than_9=y
+CT_GCC_later_than_10=y
+CT_GCC_10_or_later=y
+CT_GCC_later_than_9=y
+CT_GCC_9_or_later=y
 CT_GCC_later_than_8=y
 CT_GCC_8_or_later=y
 CT_GCC_later_than_7=y
@@ -549,6 +558,7 @@ CT_CC_GCC_CONFIG_TLS=m
 #
 CT_CC_GCC_USE_GRAPHITE=y
 CT_CC_GCC_USE_LTO=y
+CT_CC_GCC_LTO_ZSTD=m
 
 #
 # Settings for libraries running on target
@@ -564,6 +574,7 @@ CT_CC_GCC_LIBGOMP=y
 # Misc. obscure options.
 #
 CT_CC_CXA_ATEXIT=y
+CT_CC_GCC_TM_CLONE_REGISTRY=m
 # CT_CC_GCC_DISABLE_PCH is not set
 CT_CC_GCC_SJLJ_EXCEPTIONS=m
 CT_CC_GCC_LDBL_128=m
@@ -598,6 +609,8 @@ CT_GDB_PKG_NAME="gdb"
 CT_GDB_SRC_RELEASE=y
 # CT_GDB_SRC_DEVEL is not set
 CT_GDB_PATCH_ORDER="global"
+# CT_GDB_V_11 is not set
+# CT_GDB_V_10 is not set
 CT_GDB_V_9=y
 # CT_GDB_V_8_3 is not set
 CT_GDB_VERSION="9.2"
@@ -610,7 +623,6 @@ CT_GDB_11_or_older=y
 CT_GDB_older_than_11=y
 CT_GDB_10_or_older=y
 CT_GDB_older_than_10=y
-CT_GDB_REQUIRE_older_than_10=y
 CT_GDB_later_than_8_3=y
 CT_GDB_8_3_or_later=y
 CT_GDB_later_than_8_0=y
@@ -628,7 +640,6 @@ CT_GDB_CROSS_EXTRA_CONFIG_ARRAY=""
 CT_GDB_GDBSERVER=y
 # CT_GDB_NATIVE_BUILD_IPA_LIB is not set
 # CT_GDB_NATIVE_STATIC_LIBSTDCXX is not set
-CT_GDB_DEP_NO_STD_FUTURE=y
 # CT_DEBUG_LTRACE is not set
 # CT_DEBUG_STRACE is not set
 CT_ALL_DEBUG_CHOICES="DUMA GDB LTRACE STRACE"
@@ -798,6 +809,7 @@ CT_ZLIB_PATCH_ORDER="global"
 CT_ZLIB_V_1_2_12=y
 CT_ZLIB_VERSION="1.2.13"
 CT_ZLIB_MIRRORS="https://github.com/madler/zlib/releases/download/v${CT_ZLIB_VERSION} https://www.zlib.net/ https://www.zlib.net/fossils"
+
 CT_ZLIB_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ZLIB_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ZLIB_ARCHIVE_FORMATS=".tar.xz .tar.gz"


### PR DESCRIPTION
This is the version used in the manylinux2014_aarch image documented at https://github.com/pypa/manylinux.