### PR TITLE
Fix build failed with wabt on web-wasm image

### DIFF
--- a/common/common.webassembly
+++ b/common/common.webassembly
@@ -22,8 +22,8 @@ RUN git clone --recursive https://github.com/WebAssembly/binaryen.git && \
   cd ../ && \
   rm -rf binaryen*
 
-# main 2022-12-27, 1.0.32
-ENV WABT_GIT_TAG e5b042a72e6b6395e1d77901e7a413d6af87ae67
+# main 2023-03-16
+ENV WABT_GIT_TAG 090d4674c86b00e31d18e77f2c8f8570a68e1cf1
 RUN git clone --recurse-submodules https://github.com/WebAssembly/wabt.git && \
   cd wabt && \
   git checkout ${WABT_GIT_TAG} && \


### PR DESCRIPTION
**web-wasi** doesn't build on my computer and server (Manjaro and Debian 11), i updated [wabt](https://github.com/WebAssembly/wabt) to latest commit.
Current update ([1.0.32](https://github.com/WebAssembly/wabt/releases/tag/1.0.32)) doesn't not work for me :/

The commit that fixed the issue: https://github.com/WebAssembly/wabt/commit/5cb73ee2344c69e442ac6147ba7971992088f801

Build fail on **linux-arm64-full** isn't relate to this commit.

Logs (on 162287deb5aed774bdc66a220e877b5ea36e71c9 ) when i tried to build web-wasi

``` bash
make web-wasm
sed \
        -e '/common.docker/ r common/common.docker' \
        -e '/common.debian/ r common/common.debian' \
        -e '/common.manylinux_2_28/ r common/common.manylinux_2_28' \
        -e '/common.manylinux2014/ r common/common.manylinux2014' \
        -e '/common.crosstool/ r common/common.crosstool' \
        -e '/common.buildroot/ r common/common.buildroot' \
        -e '/common-manylinux.crosstool/ r common/common-manylinux.crosstool' \
        -e '/common.webassembly/ r common/common.webassembly' \
        -e '/common.windows/ r common/common.windows' \
        -e '/common.dockcross/ r common/common.dockcross' \
        -e '/common.label-and-env/ r common/common.label-and-env' \
        web-wasm/Dockerfile.in > web-wasm/Dockerfile
mkdir -p web-wasm/imagefiles && cp -r imagefiles web-wasm/
cp -r test web-wasm/
docker build -t dockcross/web-wasm:20230316-162287d \
        -t dockcross/web-wasm:latest \
        --build-arg IMAGE=dockcross/web-wasm \
        --build-arg VERSION=20230316-162287d \
        --build-arg VCS_REF=`git rev-parse --short HEAD` \
        --build-arg VCS_URL=`git config --get remote.origin.url` \
        --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
        web-wasm
[+] Building 39.6s (21/30)                                                                                                                                                                                             
 => [internal] load build definition from Dockerfile                                                                                                                                                              0.1s
 => => transferring dockerfile: 6.47kB                                                                                                                                                                            0.0s
 => [internal] load .dockerignore                                                                                                                                                                                 0.1s
 => => transferring context: 2B                                                                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/emscripten/emsdk:3.1.28                                                                                                                                                1.3s
 => [internal] load build context                                                                                                                                                                                 0.1s
 => => transferring context: 28.63kB                                                                                                                                                                              0.0s
 => [ 1/26] FROM docker.io/emscripten/emsdk:3.1.28@sha256:5637bba16c0ff5de29ad35d777e32689f3cf66821047231c7ae3987575c8c662                                                                                        0.0s
 => CACHED [ 2/26] RUN rm /bin/sh && ln -s /bin/dash /bin/sh                                                                                                                                                      0.0s
 => CACHED [ 3/26] RUN   apt-get update --yes &&   apt-get install --no-install-recommends --yes     automake     autogen     bash     build-essential     bc     bzip2     ca-certificates     curl     dirmngr  0.0s
 => CACHED [ 4/26] RUN ln -s /usr/bin/python3 /usr/bin/python                                                                                                                                                     0.0s
 => CACHED [ 5/26] WORKDIR /usr/src                                                                                                                                                                               0.0s
 => CACHED [ 6/26] COPY   imagefiles/install-gosu-binary.sh   imagefiles/install-gosu-binary-wrapper.sh   /buildscripts/                                                                                          0.0s
 => CACHED [ 7/26] RUN   set -x &&   /buildscripts/install-gosu-binary.sh &&   /buildscripts/install-gosu-binary-wrapper.sh &&   rm -rf /buildscripts                                                             0.0s
 => CACHED [ 8/26] COPY imagefiles/entrypoint.sh imagefiles/dockcross.sh /dockcross/                                                                                                                              0.0s
 => CACHED [ 9/26] WORKDIR /usr/src                                                                                                                                                                               0.0s
 => CACHED [10/26] COPY   imagefiles/build-and-install-cmake.sh   imagefiles/build-and-install-curl.sh   imagefiles/build-and-install-flatcc.sh   imagefiles/build-and-install-git.sh   imagefiles/build-and-ins  0.0s
 => CACHED [11/26] RUN   X86_FLAG=$([ "$DEFAULT_DOCKCROSS_IMAGE" = "dockcross/manylinux2014-x86" ] && echo "-32" || echo "") &&   /buildscripts/build-and-install-openssl.sh $X86_FLAG &&   /buildscripts/build-  0.0s
 => CACHED [12/26] RUN echo "root:root" | chpasswd                                                                                                                                                                0.0s
 => CACHED [13/26] WORKDIR /work                                                                                                                                                                                  0.0s
 => CACHED [14/26] COPY imagefiles/cmake.sh /usr/local/bin/cmake                                                                                                                                                  0.0s
 => CACHED [15/26] COPY imagefiles/ccmake.sh /usr/local/bin/ccmake                                                                                                                                                0.0s
 => CACHED [16/26] RUN git clone --recursive https://github.com/WebAssembly/binaryen.git &&   cd binaryen &&   git checkout cec66beba45668dbad74abd2396bb80d33595ff0 &&   cd ../ &&   mkdir binaryen-build &&     0.0s
 => ERROR [17/26] RUN git clone --recurse-submodules https://github.com/WebAssembly/wabt.git &&   cd wabt &&   git checkout e5b042a72e6b6395e1d77901e7a413d6af87ae67 &&   cd ../ &&   mkdir wabt-build &&   cd   38.0s
------                                                                                                                                                                                                                 
 > [17/26] RUN git clone --recurse-submodules https://github.com/WebAssembly/wabt.git &&   cd wabt &&   git checkout e5b042a72e6b6395e1d77901e7a413d6af87ae67 &&   cd ../ &&   mkdir wabt-build &&   cd wabt-build &&   /usr/bin/cmake     -DCMAKE_C_COMPILER=/usr/bin/cc     -DCMAKE_CXX_COMPILER=/usr/bin/c++     -G Ninja     -DCMAKE_INSTALL_PREFIX:PATH=/usr     -DCMAKE_TOOLCHAIN_FILE=""     ../wabt &&   ninja &&   ninja install &&   cd ../ &&   rm -rf wabt*:                                                                                                                                                                                             
#0 0.491 Cloning into 'wabt'...                                                                                                                                                                                        
#0 7.975 Submodule 'third_party/gtest' (https://github.com/google/googletest) registered for path 'third_party/gtest'                                                                                                  
#0 7.975 Submodule 'third_party/picosha2' (https://github.com/okdshin/PicoSHA2) registered for path 'third_party/picosha2'
#0 7.975 Submodule 'third_party/ply' (https://github.com/dabeaz/ply) registered for path 'third_party/ply'
#0 7.975 Submodule 'third_party/simde' (https://github.com/simd-everywhere/simde) registered for path 'third_party/simde'
#0 7.975 Submodule 'third_party/testsuite' (https://github.com/WebAssembly/testsuite) registered for path 'third_party/testsuite'
#0 7.975 Submodule 'third_party/uvwasi' (https://github.com/nodejs/uvwasi) registered for path 'third_party/uvwasi'
#0 7.976 Submodule 'third_party/wasm-c-api' (https://github.com/WebAssembly/wasm-c-api) registered for path 'third_party/wasm-c-api'
#0 7.977 Cloning into '/work/wabt/third_party/gtest'...
#0 13.35 Cloning into '/work/wabt/third_party/picosha2'...
#0 14.07 Cloning into '/work/wabt/third_party/ply'...
#0 14.96 Cloning into '/work/wabt/third_party/simde'...
#0 21.99 Cloning into '/work/wabt/third_party/testsuite'...
#0 23.55 Cloning into '/work/wabt/third_party/uvwasi'...
#0 24.75 Cloning into '/work/wabt/third_party/wasm-c-api'...
#0 25.61 Submodule path 'third_party/gtest': checked out '703bd9caab50b139428cea1aaff9974ebee5742e'
#0 25.61 Submodule path 'third_party/picosha2': checked out '27fcf6979298949e8a462e16d09a0351c18fcaf2'
#0 25.63 Submodule path 'third_party/ply': checked out 'd776a2ece6c12bf8f8b6a0e65b48546ac6078765'
#0 25.78 Submodule path 'third_party/simde': checked out '97315b87d7300cbf1472a2b34802366efe376b5e'
#0 25.78 Submodule 'munit' (https://github.com/nemequ/munit.git) registered for path 'third_party/simde/test/munit'
#0 25.78 Cloning into '/work/wabt/third_party/simde/test/munit'...
#0 26.55 Submodule path 'third_party/simde/test/munit': checked out 'da8f73412998e4f1adf1100dc187533a51af77fd'
#0 26.58 Submodule path 'third_party/testsuite': checked out '7ef86ddeed81458f9031a49a40b3a3f99c1c6a8a'
#0 26.59 Submodule path 'third_party/uvwasi': checked out '55eff19f4c7e69ec151424a037f951e0ad006ed6'
#0 26.60 Submodule path 'third_party/wasm-c-api': checked out 'b6dd1fb658a282c64b029867845bc50ae59e1497'
#0 26.64 warning: unable to rmdir 'third_party/picosha2': Directory not empty
#0 26.64 warning: unable to rmdir 'third_party/simde': Directory not empty
#0 26.67 HEAD is now at e5b042a7 Version 1.0.32 (#2111)
#0 26.67 M      third_party/testsuite
#0 26.67 M      third_party/wasm-c-api
#0 26.75 -- The C compiler identification is GNU 11.3.0
#0 26.80 -- The CXX compiler identification is GNU 11.3.0
#0 26.80 -- Detecting C compiler ABI info
#0 26.84 -- Detecting C compiler ABI info - done
#0 26.84 -- Check for working C compiler: /usr/bin/cc - skipped
#0 26.84 -- Detecting C compile features
#0 26.84 -- Detecting C compile features - done
#0 26.85 -- Detecting CXX compiler ABI info
#0 26.89 -- Detecting CXX compiler ABI info - done
#0 26.89 -- Check for working CXX compiler: /usr/bin/c++ - skipped
#0 26.89 -- Detecting CXX compile features
#0 26.89 -- Detecting CXX compile features - done
#0 26.90 -- Found Git: /usr/local/bin/git (found version "2.36.1") 
#0 26.90 -- Looking for alloca.h
#0 26.93 -- Looking for alloca.h - found
#0 26.93 -- Looking for unistd.h
#0 26.97 -- Looking for unistd.h - found
#0 26.97 -- Looking for snprintf
#0 27.00 -- Looking for snprintf - found
#0 27.00 -- Looking for strcasecmp
#0 27.03 -- Looking for strcasecmp - found
#0 27.03 -- Looking for sys/types.h
#0 27.07 -- Looking for sys/types.h - found
#0 27.07 -- Looking for stdint.h
#0 27.10 -- Looking for stdint.h - found
#0 27.10 -- Looking for stddef.h
#0 27.13 -- Looking for stddef.h - found
#0 27.13 -- Check size of ssize_t
#0 27.16 -- Check size of ssize_t - done
#0 27.16 -- Check size of size_t
#0 27.19 -- Check size of size_t - done
#0 27.20 -- Looking for __i386__
#0 27.21 -- Looking for __i386__ - not found
#0 27.21 -- Looking for __SSE2_MATH__
#0 27.24 -- Looking for __SSE2_MATH__ - found
#0 27.24 -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
#0 27.28 -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
#0 27.28 -- Found Threads: TRUE  
#0 27.30 -- Found PythonInterp: /usr/bin/python3 (found suitable version "3.10.6", minimum required is "3.5") 
#0 27.30 -- Configuring done
#0 27.33 -- Generating done
#0 27.33 -- Build files have been written to: /work/wabt-build
#0 27.35 [1/192] Generating wasm2c_header_top.cc, wasm2c_header_bottom.cc, wasm2c_source_includes.cc, wasm2c_source_declarations.cc
#0 27.40 [2/192] Building CXX object CMakeFiles/wabt.dir/src/config.cc.o
#0 27.41 [3/192] Building C object CMakeFiles/wasm-rt-impl.dir/wasm2c/wasm-rt-impl.c.o
#0 27.89 [4/192] Building CXX object CMakeFiles/wabt.dir/src/binary.cc.o
#0 27.92 [5/192] Building CXX object CMakeFiles/wabt.dir/src/error-formatter.cc.o
#0 27.93 [6/192] Building CXX object CMakeFiles/wabt.dir/src/common.cc.o
#0 28.02 [7/192] Building CXX object CMakeFiles/wabt.dir/src/color.cc.o
#0 28.19 [8/192] Building CXX object CMakeFiles/wabt.dir/src/filenames.cc.o
#0 28.32 [9/192] Building CXX object CMakeFiles/wabt.dir/src/binary-reader-logging.cc.o
#0 28.44 [10/192] Building CXX object CMakeFiles/wabt.dir/src/feature.cc.o
#0 28.51 [11/192] Building CXX object CMakeFiles/wabt.dir/src/binding-hash.cc.o
#0 28.53 [12/192] Building C object CMakeFiles/wabt.dir/src/opcode-code-table.c.o
#0 28.54 [13/192] Building CXX object CMakeFiles/wabt.dir/src/apply-names.cc.o
#0 28.72 [14/192] Building CXX object CMakeFiles/wabt.dir/src/leb128.cc.o
#0 28.75 [15/192] Building CXX object CMakeFiles/wabt.dir/src/binary-writer-spec.cc.o
#0 28.82 [16/192] Building CXX object CMakeFiles/wabt.dir/src/lexer-source-line-finder.cc.o
#0 28.84 [17/192] Building CXX object CMakeFiles/wabt.dir/src/generate-names.cc.o
#0 28.91 [18/192] Building CXX object CMakeFiles/wabt.dir/src/binary-reader.cc.o
#0 28.93 [19/192] Building CXX object CMakeFiles/gtest_main.dir/third_party/gtest/googletest/src/gtest_main.cc.o
#0 28.95 [20/192] Building CXX object CMakeFiles/wabt.dir/src/expr-visitor.cc.o
#0 28.96 [21/192] Building CXX object CMakeFiles/wabt.dir/src/lexer-source.cc.o
#0 29.03 [22/192] Building CXX object CMakeFiles/wabt.dir/src/utf8.cc.o
#0 29.13 [23/192] Building CXX object CMakeFiles/wabt.dir/src/ir-util.cc.o
#0 29.42 [24/192] Building CXX object CMakeFiles/wabt.dir/src/literal.cc.o
#0 29.45 [25/192] Building CXX object CMakeFiles/wabt.dir/src/option-parser.cc.o
#0 29.49 [26/192] Building CXX object CMakeFiles/wabt.dir/wasm2c_header_top.cc.o
#0 29.52 [27/192] Building CXX object CMakeFiles/wabt.dir/src/token.cc.o
#0 29.54 [28/192] Building CXX object CMakeFiles/wabt.dir/wasm2c_header_bottom.cc.o
#0 29.54 [29/192] Building CXX object CMakeFiles/wabt.dir/src/tracing.cc.o
#0 29.55 [30/192] Building CXX object CMakeFiles/wabt.dir/src/stream.cc.o
#0 29.57 [31/192] Building CXX object CMakeFiles/wabt.dir/wasm2c_source_declarations.cc.o
#0 29.57 [32/192] Building CXX object CMakeFiles/wabt.dir/wasm2c_source_includes.cc.o
#0 29.79 [33/192] Building CXX object CMakeFiles/wabt.dir/src/opcode.cc.o
#0 29.93 [34/192] Linking C static library libwasm-rt-impl.a
#0 30.00 [35/192] Building CXX object CMakeFiles/wabt.dir/src/type-checker.cc.o
#0 30.20 [36/192] Building CXX object CMakeFiles/wabt.dir/src/binary-writer.cc.o
#0 30.40 [37/192] Building CXX object CMakeFiles/wabt.dir/src/wast-lexer.cc.o
#0 30.48 [38/192] Building CXX object CMakeFiles/wabt.dir/src/resolve-names.cc.o
#0 30.50 [39/192] Building CXX object CMakeFiles/wabt.dir/src/decompiler.cc.o
#0 30.52 [40/192] Building CXX object CMakeFiles/wabt.dir/src/ir.cc.o
#0 30.60 [41/192] Building CXX object CMakeFiles/wabt.dir/src/interp/istream.cc.o
#0 30.62 [42/192] Building CXX object CMakeFiles/wabt.dir/src/interp/interp-util.cc.o
#0 31.24 [43/192] Building CXX object CMakeFiles/wabt.dir/src/validator.cc.o
#0 31.25 [44/192] Building CXX object CMakeFiles/wasm.dir/src/apply-names.cc.o
#0 31.27 [45/192] Building CXX object CMakeFiles/wabt.dir/src/shared-validator.cc.o
#0 31.28 [46/192] Building CXX object CMakeFiles/wasm.dir/src/binary-reader-logging.cc.o
#0 31.30 [47/192] Building CXX object CMakeFiles/wasm.dir/src/binary.cc.o
#0 31.33 [48/192] Building CXX object CMakeFiles/wasm.dir/src/config.cc.o
#0 31.37 [49/192] Building CXX object CMakeFiles/wasm.dir/src/color.cc.o
#0 31.39 [50/192] Building CXX object CMakeFiles/wabt.dir/src/wat-writer.cc.o
#0 31.86 [51/192] Building CXX object CMakeFiles/wasm.dir/src/binary-writer-spec.cc.o
#0 31.86 [52/192] Building CXX object CMakeFiles/wasm.dir/src/binding-hash.cc.o
#0 32.02 [53/192] Building CXX object CMakeFiles/wasm.dir/src/common.cc.o
#0 32.07 [54/192] Building CXX object CMakeFiles/wasm.dir/src/filenames.cc.o
#0 32.09 [55/192] Building CXX object CMakeFiles/wasm.dir/src/binary-reader.cc.o
#0 32.13 [56/192] Building CXX object CMakeFiles/wasm.dir/src/error-formatter.cc.o
#0 32.31 [57/192] Building CXX object CMakeFiles/gtest.dir/third_party/gtest/googletest/src/gtest-all.cc.o
#0 32.40 [58/192] Building C object CMakeFiles/wasm.dir/src/opcode-code-table.c.o
#0 32.44 [59/192] Building CXX object CMakeFiles/wasm.dir/src/feature.cc.o
#0 32.68 [60/192] Building CXX object CMakeFiles/wasm.dir/src/expr-visitor.cc.o
#0 32.77 [61/192] Building CXX object CMakeFiles/wasm.dir/src/lexer-source.cc.o
#0 32.89 [62/192] Building CXX object CMakeFiles/wasm.dir/src/lexer-source-line-finder.cc.o
#0 32.89 [63/192] Building CXX object CMakeFiles/wasm.dir/src/leb128.cc.o
#0 32.90 [64/192] Building CXX object CMakeFiles/wasm.dir/src/generate-names.cc.o
#0 32.95 [65/192] Building CXX object CMakeFiles/wabt.dir/src/c-writer.cc.o
#0 33.03 [66/192] Building CXX object CMakeFiles/wabt.dir/src/interp/binary-reader-interp.cc.o
#0 33.09 [67/192] Building CXX object CMakeFiles/wasm.dir/src/utf8.cc.o
#0 33.13 [68/192] Building CXX object CMakeFiles/wasm.dir/src/binary-writer.cc.o
#0 33.14 [69/192] Building CXX object CMakeFiles/wasm.dir/src/ir-util.cc.o
#0 33.28 [70/192] Building CXX object CMakeFiles/wasm.dir/src/literal.cc.o
#0 33.56 [71/192] Building CXX object CMakeFiles/wasm.dir/src/tracing.cc.o
#0 33.59 [72/192] Building CXX object CMakeFiles/wasm.dir/src/option-parser.cc.o
#0 33.64 [73/192] Building CXX object CMakeFiles/wasm.dir/src/opcode.cc.o
#0 33.66 [74/192] Building CXX object CMakeFiles/wasm.dir/wasm2c_header_top.cc.o
#0 33.66 [75/192] Building CXX object CMakeFiles/wasm.dir/src/token.cc.o
#0 33.68 [76/192] Building CXX object CMakeFiles/wasm.dir/src/stream.cc.o
#0 33.69 [77/192] Building CXX object CMakeFiles/wasm.dir/wasm2c_header_bottom.cc.o
#0 33.69 [78/192] Building CXX object CMakeFiles/wasm.dir/wasm2c_source_includes.cc.o
#0 33.73 [79/192] Building CXX object CMakeFiles/wasm.dir/wasm2c_source_declarations.cc.o
#0 33.76 [80/192] Building CXX object CMakeFiles/wabt.dir/src/binary-reader-ir.cc.o
#0 33.92 [81/192] Building CXX object CMakeFiles/wabt.dir/src/interp/interp.cc.o
#0 34.23 [82/192] Building CXX object CMakeFiles/wasm.dir/src/ir.cc.o
#0 34.24 [83/192] Building CXX object CMakeFiles/wasm.dir/src/decompiler.cc.o
#0 34.26 [84/192] Building CXX object CMakeFiles/wasm.dir/src/resolve-names.cc.o
#0 34.27 [85/192] Building CXX object CMakeFiles/wasm.dir/src/type-checker.cc.o
#0 34.52 [86/192] Building CXX object CMakeFiles/wasm.dir/src/interp/istream.cc.o
#0 34.60 [87/192] Building CXX object CMakeFiles/wasm.dir/src/wast-lexer.cc.o
#0 34.95 [88/192] Building CXX object CMakeFiles/wasm.dir/src/interp/interp-util.cc.o
#0 35.09 [89/192] Building CXX object CMakeFiles/wasm.dir/src/validator.cc.o
#0 35.39 [90/192] Building CXX object CMakeFiles/wasm.dir/src/interp/interp-wasm-c-api.cc.o
#0 35.39 FAILED: CMakeFiles/wasm.dir/src/interp/interp-wasm-c-api.cc.o 
#0 35.39 /usr/bin/c++ -DWASM_API_EXTERN="__attribute__((visibility(\"default\")))" -D__STDC_FORMAT_MACROS=1 -D__STDC_LIMIT_MACROS=1 -Dwasm_EXPORTS -I/work/wabt/third_party/wasm-c-api/include -I/work/wabt/third_party/gtest/googletest -I/work/wabt/third_party/gtest/googletest/include -I/work/wabt/include -I/work/wabt-build/include -Wold-style-cast -fno-exceptions -fPIC -fvisibility=hidden   -Wall -Wextra -Wno-unused-parameter -Wpointer-arith -Wuninitialized -Wno-clobbered -Wno-old-style-cast -std=c++17 -MD -MT CMakeFiles/wasm.dir/src/interp/interp-wasm-c-api.cc.o -MF CMakeFiles/wasm.dir/src/interp/interp-wasm-c-api.cc.o.d -o CMakeFiles/wasm.dir/src/interp/interp-wasm-c-api.cc.o -c /work/wabt/src/interp/interp-wasm-c-api.cc
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc:727:22: error: conflicting declaration of C function 'wasm_instance_t* wasm_instance_new(wasm_store_t*, const wasm_module_t*, const wasm_extern_t* const*, wasm_trap_t**)'
#0 35.39   727 | own wasm_instance_t* wasm_instance_new(wasm_store_t* store,
#0 35.39       |                      ^~~~~~~~~~~~~~~~~
#0 35.39 In file included from /work/wabt/src/interp/interp-wasm-c-api.cc:17:
#0 35.39 /work/wabt/third_party/wasm-c-api/include/wasm.h:518:38: note: previous declaration 'wasm_instance_t* wasm_instance_new(wasm_store_t*, const wasm_module_t*, const wasm_extern_vec_t*, wasm_trap_t**)'
#0 35.39   518 | WASM_API_EXTERN own wasm_instance_t* wasm_instance_new(
#0 35.39       |                                      ^~~~~~~~~~~~~~~~~
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc: In lambda function:
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc:794:33: error: cannot convert 'wasm_val_t*' to 'const wasm_val_vec_t*' in argument passing
#0 35.39   794 |     auto trap = callback(params.data, results.data);
#0 35.39       |                          ~~~~~~~^~~~
#0 35.39       |                                 |
#0 35.39       |                                 wasm_val_t*
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc:797:34: error: expected primary-expression before '>' token
#0 35.39   797 |       *out_trap = trap->I.As<Trap>();
#0 35.39       |                                  ^
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc:797:36: error: expected primary-expression before ')' token
#0 35.39   797 |       *out_trap = trap->I.As<Trap>();
#0 35.39       |                                    ^
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc: In lambda function:
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc:823:38: error: cannot convert 'wasm_val_t*' to 'const wasm_val_vec_t*' in argument passing
#0 35.39   823 |     auto trap = callback(env, params.data, results.data);
#0 35.39       |                               ~~~~~~~^~~~
#0 35.39       |                                      |
#0 35.39       |                                      wasm_val_t*
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc:826:34: error: expected primary-expression before '>' token
#0 35.39   826 |       *out_trap = trap->I.As<Trap>();
#0 35.39       |                                  ^
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc:826:36: error: expected primary-expression before ')' token
#0 35.39   826 |       *out_trap = trap->I.As<Trap>();
#0 35.39       |                                    ^
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc: At global scope:
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc:854:18: error: conflicting declaration of C function 'wasm_trap_t* wasm_func_call(const wasm_func_t*, const wasm_val_t*, wasm_val_t*)'
#0 35.39   854 | own wasm_trap_t* wasm_func_call(const wasm_func_t* f,
#0 35.39       |                  ^~~~~~~~~~~~~~
#0 35.39 In file included from /work/wabt/src/interp/interp-wasm-c-api.cc:17:
#0 35.39 /work/wabt/third_party/wasm-c-api/include/wasm.h:431:34: note: previous declaration 'wasm_trap_t* wasm_func_call(const wasm_func_t*, const wasm_val_vec_t*, wasm_val_vec_t*)'
#0 35.39   431 | WASM_API_EXTERN own wasm_trap_t* wasm_func_call(
#0 35.39       |                                  ^~~~~~~~~~~~~~
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc:1181:24: error: conflicting declaration of C function 'wasm_valtype_t* wasm_valtype_copy(wasm_valtype_t*)'
#0 35.39  1181 |   own wasm_##name##_t* wasm_##name##_copy(wasm_##name##_t* other) { \
#0 35.39       |                        ^~~~~
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc:1186:1: note: in expansion of macro 'WASM_IMPL_TYPE'
#0 35.39  1186 | WASM_IMPL_TYPE(valtype);
#0 35.39       | ^~~~~~~~~~~~~~
#0 35.39 In file included from /work/wabt/src/interp/interp-wasm-c-api.cc:17:
#0 35.39 /work/wabt/third_party/wasm-c-api/include/wasm.h:172:40: note: previous declaration 'wasm_valtype_t* wasm_valtype_copy(const wasm_valtype_t*)'
#0 35.39   172 |   WASM_API_EXTERN own wasm_##name##_t* wasm_##name##_copy(const wasm_##name##_t*);
#0 35.39       |                                        ^~~~~
#0 35.39 /work/wabt/third_party/wasm-c-api/include/wasm.h:177:1: note: in expansion of macro 'WASM_DECLARE_TYPE'
#0 35.39   177 | WASM_DECLARE_TYPE(valtype)
#0 35.39       | ^~~~~~~~~~~~~~~~~
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc:1181:24: error: conflicting declaration of C function 'wasm_importtype_t* wasm_importtype_copy(wasm_importtype_t*)'
#0 35.39  1181 |   own wasm_##name##_t* wasm_##name##_copy(wasm_##name##_t* other) { \
#0 35.39       |                        ^~~~~
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc:1187:1: note: in expansion of macro 'WASM_IMPL_TYPE'
#0 35.39  1187 | WASM_IMPL_TYPE(importtype);
#0 35.39       | ^~~~~~~~~~~~~~
#0 35.39 In file included from /work/wabt/src/interp/interp-wasm-c-api.cc:17:
#0 35.39 /work/wabt/third_party/wasm-c-api/include/wasm.h:172:40: note: previous declaration 'wasm_importtype_t* wasm_importtype_copy(const wasm_importtype_t*)'
#0 35.39   172 |   WASM_API_EXTERN own wasm_##name##_t* wasm_##name##_copy(const wasm_##name##_t*);
#0 35.39       |                                        ^~~~~
#0 35.39 /work/wabt/third_party/wasm-c-api/include/wasm.h:287:1: note: in expansion of macro 'WASM_DECLARE_TYPE'
#0 35.39   287 | WASM_DECLARE_TYPE(importtype)
#0 35.39       | ^~~~~~~~~~~~~~~~~
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc:1181:24: error: conflicting declaration of C function 'wasm_exporttype_t* wasm_exporttype_copy(wasm_exporttype_t*)'
#0 35.39  1181 |   own wasm_##name##_t* wasm_##name##_copy(wasm_##name##_t* other) { \
#0 35.39       |                        ^~~~~
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc:1188:1: note: in expansion of macro 'WASM_IMPL_TYPE'
#0 35.39  1188 | WASM_IMPL_TYPE(exporttype);
#0 35.39       | ^~~~~~~~~~~~~~
#0 35.39 In file included from /work/wabt/src/interp/interp-wasm-c-api.cc:17:
#0 35.39 /work/wabt/third_party/wasm-c-api/include/wasm.h:172:40: note: previous declaration 'wasm_exporttype_t* wasm_exporttype_copy(const wasm_exporttype_t*)'
#0 35.39   172 |   WASM_API_EXTERN own wasm_##name##_t* wasm_##name##_copy(const wasm_##name##_t*);
#0 35.39       |                                        ^~~~~
#0 35.39 /work/wabt/third_party/wasm-c-api/include/wasm.h:299:1: note: in expansion of macro 'WASM_DECLARE_TYPE'
#0 35.39   299 | WASM_DECLARE_TYPE(exporttype)
#0 35.39       | ^~~~~~~~~~~~~~~~~
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc:1193:24: error: conflicting declaration of C function 'wasm_functype_t* wasm_functype_copy(wasm_functype_t*)'
#0 35.39  1193 |   own wasm_##name##_t* wasm_##name##_copy(wasm_##name##_t* other) { \
#0 35.39       |                        ^~~~~
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc:1198:1: note: in expansion of macro 'WASM_IMPL_TYPE_CLONE'
#0 35.39  1198 | WASM_IMPL_TYPE_CLONE(functype);
#0 35.39       | ^~~~~~~~~~~~~~~~~~~~
#0 35.39 In file included from /work/wabt/src/interp/interp-wasm-c-api.cc:17:
#0 35.39 /work/wabt/third_party/wasm-c-api/include/wasm.h:172:40: note: previous declaration 'wasm_functype_t* wasm_functype_copy(const wasm_functype_t*)'
#0 35.39   172 |   WASM_API_EXTERN own wasm_##name##_t* wasm_##name##_copy(const wasm_##name##_t*);
#0 35.39       |                                        ^~~~~
#0 35.39 /work/wabt/third_party/wasm-c-api/include/wasm.h:210:1: note: in expansion of macro 'WASM_DECLARE_TYPE'
#0 35.39   210 | WASM_DECLARE_TYPE(functype)
#0 35.39       | ^~~~~~~~~~~~~~~~~
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc:1193:24: error: conflicting declaration of C function 'wasm_globaltype_t* wasm_globaltype_copy(wasm_globaltype_t*)'
#0 35.39  1193 |   own wasm_##name##_t* wasm_##name##_copy(wasm_##name##_t* other) { \
#0 35.39       |                        ^~~~~
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc:1199:1: note: in expansion of macro 'WASM_IMPL_TYPE_CLONE'
#0 35.39  1199 | WASM_IMPL_TYPE_CLONE(globaltype);
#0 35.39       | ^~~~~~~~~~~~~~~~~~~~
#0 35.39 In file included from /work/wabt/src/interp/interp-wasm-c-api.cc:17:
#0 35.39 /work/wabt/third_party/wasm-c-api/include/wasm.h:172:40: note: previous declaration 'wasm_globaltype_t* wasm_globaltype_copy(const wasm_globaltype_t*)'
#0 35.39   172 |   WASM_API_EXTERN own wasm_##name##_t* wasm_##name##_copy(const wasm_##name##_t*);
#0 35.39       |                                        ^~~~~
#0 35.39 /work/wabt/third_party/wasm-c-api/include/wasm.h:221:1: note: in expansion of macro 'WASM_DECLARE_TYPE'
#0 35.39   221 | WASM_DECLARE_TYPE(globaltype)
#0 35.39       | ^~~~~~~~~~~~~~~~~
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc:1193:24: error: conflicting declaration of C function 'wasm_tabletype_t* wasm_tabletype_copy(wasm_tabletype_t*)'
#0 35.39  1193 |   own wasm_##name##_t* wasm_##name##_copy(wasm_##name##_t* other) { \
#0 35.39       |                        ^~~~~
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc:1200:1: note: in expansion of macro 'WASM_IMPL_TYPE_CLONE'
#0 35.39  1200 | WASM_IMPL_TYPE_CLONE(tabletype);
#0 35.39       | ^~~~~~~~~~~~~~~~~~~~
#0 35.39 In file included from /work/wabt/src/interp/interp-wasm-c-api.cc:17:
#0 35.39 /work/wabt/third_party/wasm-c-api/include/wasm.h:172:40: note: previous declaration 'wasm_tabletype_t* wasm_tabletype_copy(const wasm_tabletype_t*)'
#0 35.39   172 |   WASM_API_EXTERN own wasm_##name##_t* wasm_##name##_copy(const wasm_##name##_t*);
#0 35.39       |                                        ^~~~~
#0 35.39 /work/wabt/third_party/wasm-c-api/include/wasm.h:232:1: note: in expansion of macro 'WASM_DECLARE_TYPE'
#0 35.39   232 | WASM_DECLARE_TYPE(tabletype)
#0 35.39       | ^~~~~~~~~~~~~~~~~
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc:1193:24: error: conflicting declaration of C function 'wasm_memorytype_t* wasm_memorytype_copy(wasm_memorytype_t*)'
#0 35.39  1193 |   own wasm_##name##_t* wasm_##name##_copy(wasm_##name##_t* other) { \
#0 35.39       |                        ^~~~~
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc:1201:1: note: in expansion of macro 'WASM_IMPL_TYPE_CLONE'
#0 35.39  1201 | WASM_IMPL_TYPE_CLONE(memorytype);
#0 35.39       | ^~~~~~~~~~~~~~~~~~~~
#0 35.39 In file included from /work/wabt/src/interp/interp-wasm-c-api.cc:17:
#0 35.39 /work/wabt/third_party/wasm-c-api/include/wasm.h:172:40: note: previous declaration 'wasm_memorytype_t* wasm_memorytype_copy(const wasm_memorytype_t*)'
#0 35.39   172 |   WASM_API_EXTERN own wasm_##name##_t* wasm_##name##_copy(const wasm_##name##_t*);
#0 35.39       |                                        ^~~~~
#0 35.39 /work/wabt/third_party/wasm-c-api/include/wasm.h:243:1: note: in expansion of macro 'WASM_DECLARE_TYPE'
#0 35.39   243 | WASM_DECLARE_TYPE(memorytype)
#0 35.39       | ^~~~~~~~~~~~~~~~~
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc:1193:24: error: conflicting declaration of C function 'wasm_externtype_t* wasm_externtype_copy(wasm_externtype_t*)'
#0 35.39  1193 |   own wasm_##name##_t* wasm_##name##_copy(wasm_##name##_t* other) { \
#0 35.39       |                        ^~~~~
#0 35.39 /work/wabt/src/interp/interp-wasm-c-api.cc:1202:1: note: in expansion of macro 'WASM_IMPL_TYPE_CLONE'
#0 35.39  1202 | WASM_IMPL_TYPE_CLONE(externtype);
#0 35.39       | ^~~~~~~~~~~~~~~~~~~~
#0 35.39 In file included from /work/wabt/src/interp/interp-wasm-c-api.cc:17:
#0 35.39 /work/wabt/third_party/wasm-c-api/include/wasm.h:172:40: note: previous declaration 'wasm_externtype_t* wasm_externtype_copy(const wasm_externtype_t*)'
#0 35.39   172 |   WASM_API_EXTERN own wasm_##name##_t* wasm_##name##_copy(const wasm_##name##_t*);
#0 35.39       |                                        ^~~~~
#0 35.39 /work/wabt/third_party/wasm-c-api/include/wasm.h:252:1: note: in expansion of macro 'WASM_DECLARE_TYPE'
#0 35.39   252 | WASM_DECLARE_TYPE(externtype)
#0 35.39       | ^~~~~~~~~~~~~~~~~
#0 35.45 [91/192] Building CXX object CMakeFiles/wasm.dir/src/shared-validator.cc.o
#0 35.53 [92/192] Building CXX object CMakeFiles/wasm.dir/src/wat-writer.cc.o
#0 35.73 [93/192] Building CXX object CMakeFiles/wat2wasm.dir/src/tools/wat2wasm.cc.o
#0 35.77 [94/192] Building CXX object CMakeFiles/wasm-objdump.dir/src/tools/wasm-objdump.cc.o
#0 35.92 [95/192] Building CXX object CMakeFiles/wasm2c.dir/src/tools/wasm2c.cc.o
#0 35.94 [96/192] Building CXX object CMakeFiles/wasm-opcodecnt.dir/src/tools/wasm-opcodecnt.cc.o
#0 35.99 [97/192] Building CXX object CMakeFiles/wasm2wat.dir/src/tools/wasm2wat.cc.o
#0 36.00 [98/192] Building CXX object CMakeFiles/wast2json.dir/src/tools/wast2json.cc.o
#0 36.17 [99/192] Building CXX object CMakeFiles/wasm-opcodecnt.dir/src/binary-reader-opcnt.cc.o
#0 36.23 [100/192] Building CXX object CMakeFiles/wabt.dir/src/wast-parser.cc.o
#0 36.37 [101/192] Building CXX object CMakeFiles/wasm-objdump.dir/src/binary-reader-objdump.cc.o
#0 36.63 [102/192] Building CXX object CMakeFiles/wasm.dir/src/binary-reader-ir.cc.o
#0 36.64 [103/192] Building CXX object CMakeFiles/wasm.dir/src/c-writer.cc.o
#0 36.67 [104/192] Building CXX object CMakeFiles/wasm.dir/src/interp/binary-reader-interp.cc.o
#0 36.70 [105/192] Building CXX object CMakeFiles/wasm-interp.dir/src/tools/wasm-interp.cc.o
#0 37.10 [106/192] Building CXX object CMakeFiles/wasm.dir/src/interp/interp.cc.o
#0 37.91 [107/192] Building CXX object CMakeFiles/wasm.dir/src/wast-parser.cc.o
#0 37.91 ninja: build stopped: subcommand failed.
------
Dockerfile:155
--------------------
 154 |     ENV WABT_GIT_TAG e5b042a72e6b6395e1d77901e7a413d6af87ae67
 155 | >>> RUN git clone --recurse-submodules https://github.com/WebAssembly/wabt.git && \
 156 | >>>   cd wabt && \
 157 | >>>   git checkout ${WABT_GIT_TAG} && \
 158 | >>>   cd ../ && \
 159 | >>>   mkdir wabt-build && \
 160 | >>>   cd wabt-build && \
 161 | >>>   /usr/bin/cmake \
 162 | >>>     -DCMAKE_C_COMPILER=/usr/bin/cc \
 163 | >>>     -DCMAKE_CXX_COMPILER=/usr/bin/c++ \
 164 | >>>     -G Ninja \
 165 | >>>     -DCMAKE_INSTALL_PREFIX:PATH=/usr \
 166 | >>>     -DCMAKE_TOOLCHAIN_FILE="" \
 167 | >>>     ../wabt && \
 168 | >>>   ninja && \
 169 | >>>   ninja install && \
 170 | >>>   cd ../ && \
 171 | >>>   rm -rf wabt*
 172 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c git clone --recurse-submodules https://github.com/WebAssembly/wabt.git &&   cd wabt &&   git checkout ${WABT_GIT_TAG} &&   cd ../ &&   mkdir wabt-build &&   cd wabt-build &&   /usr/bin/cmake     -DCMAKE_C_COMPILER=/usr/bin/cc     -DCMAKE_CXX_COMPILER=/usr/bin/c++     -G Ninja     -DCMAKE_INSTALL_PREFIX:PATH=/usr     -DCMAKE_TOOLCHAIN_FILE=\"\"     ../wabt &&   ninja &&   ninja install &&   cd ../ &&   rm -rf wabt*" did not complete successfully: exit code: 1
make: *** [Makefile:119: web-wasm] Error 1
```