### PR TITLE
web-wasm: Bump emscripten to 3.1.35

### DIFF
--- a/web-wasm/Dockerfile.in
+++ b/web-wasm/Dockerfile.in
@@ -1,4 +1,4 @@
-ARG DOCKER_IMAGE_VERSION=3.1.28
+ARG DOCKER_IMAGE_VERSION=3.1.35
 FROM emscripten/emsdk:$DOCKER_IMAGE_VERSION
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"


### PR DESCRIPTION
closes https://github.com/dockcross/dockcross/issues/776