### PR TITLE
fix: git seems to sometimes require more time to download

### DIFF
--- a/imagefiles/build-and-install-git.sh
+++ b/imagefiles/build-and-install-git.sh
@@ -26,10 +26,10 @@ cd /usr/src
 url="https://mirrors.edge.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz"
 echo "Downloading $url"
 curl --connect-timeout 20 \
-    --max-time 10 \
+    --max-time 300 \
     --retry 5 \
     --retry-delay 10 \
-    --retry-max-time 40 \
+    --retry-max-time 300 \
     -# -LO $url
 
 tar xvzf "git-${GIT_VERSION}.tar.gz" --no-same-owner


### PR DESCRIPTION
https://github.com/dockcross/dockcross/pull/796 has been timing out for 2 days when downloading git. Let's try to increase the timeout slightly.