### PR TITLE
install-gosu-binary: fix arch detection to match gosu releases

### DIFF
--- a/imagefiles/install-gosu-binary.sh
+++ b/imagefiles/install-gosu-binary.sh
@@ -14,7 +14,7 @@ if ! command -v gpg &> /dev/null; then
 fi
 
 GOSU_VERSION=1.12
-dpkgArch=$(if test "$(uname -m)" = "x86_64"; then echo amd64; else echo i386; fi)
+dpkgArch="$(dpkg --print-architecture | sed 's/.*-//')"
 url="https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}"
 url_key="https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}.asc"
 

--- a/imagefiles/install-gosu-binary.sh
+++ b/imagefiles/install-gosu-binary.sh
@@ -14,9 +14,44 @@ if ! command -v gpg &> /dev/null; then
 fi
 
 GOSU_VERSION=1.12
-dpkgArch="$(dpkg --print-architecture | sed 's/.*-//')"
-url="https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}"
-url_key="https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}.asc"
+
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64)
+        GOSU_ARCH=amd64
+        ;;
+    aarch64)
+        GOSU_ARCH=arm64
+        ;;
+    armv7l)
+        GOSU_ARCH=armhf
+        ;;
+    armv6l)
+        GOSU_ARCH=armel
+        ;;
+    i686|i386)
+        GOSU_ARCH=i386
+        ;;
+    mips64el)
+        GOSU_ARCH=mips64el
+        ;;
+    ppc64el)
+        GOSU_ARCH=ppc64el
+        ;;
+    riscv64)
+        GOSU_ARCH=riscv64
+        ;;
+    s390x)
+        GOSU_ARCH=s390x
+        ;;
+    *)
+        echo "Error: unsupported arch (${ARCH}) by gosu (https://github.com/tianon/gosu/releases)" >&2
+        exit 1
+        ;;
+esac
+
+url="https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${GOSU_ARCH}"
+url_key="https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${GOSU_ARCH}.asc"
 
 # download and verify the signature
 export GNUPGHOME="$(mktemp -d)"


### PR DESCRIPTION
Fix architecture detection to match gosu's naming