### PR TITLE
Fix RISCV typos

### DIFF
--- a/linux-riscv32/Dockerfile.in
+++ b/linux-riscv32/Dockerfile.in
@@ -44,6 +44,6 @@ ENV PKG_CONFIG_PATH /usr/lib/riscv64-unknown-linux-gnu/pkgconfig
 # Linux kernel cross compilation variables
 ENV PATH ${PATH}:${CROSS_ROOT}/bin
 ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH powerpc
+ENV ARCH riscv32
 
 #include "common.label-and-env"

--- a/linux-riscv32/Dockerfile.in
+++ b/linux-riscv32/Dockerfile.in
@@ -39,7 +39,7 @@ WORKDIR /work
 COPY Toolchain.cmake /usr/lib/${CROSS_TRIPLE}/
 ENV CMAKE_TOOLCHAIN_FILE /usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
 
-ENV PKG_CONFIG_PATH /usr/lib/riscv64-unknown-linux-gnu/pkgconfig
+ENV PKG_CONFIG_PATH /usr/lib/riscv32-unknown-linux-gnu/pkgconfig
 
 # Linux kernel cross compilation variables
 ENV PATH ${PATH}:${CROSS_ROOT}/bin

--- a/linux-riscv64/Dockerfile.in
+++ b/linux-riscv64/Dockerfile.in
@@ -44,6 +44,6 @@ ENV PKG_CONFIG_PATH /usr/lib/riscv64-unknown-linux-gnu/pkgconfig
 # Linux kernel cross compilation variables
 ENV PATH ${PATH}:${CROSS_ROOT}/bin
 ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH powerpc
+ENV ARCH riscv64
 
 #include "common.label-and-env"


### PR DESCRIPTION
I believe a copy/paste error occurred while creating the RISCV32 and RISCV64 images where ARCH was set to `powerpc`.

Furthemore, I'm unsure if this is a typo:

https://github.com/dockcross/dockcross/blob/4282105d1189e7843dca3654d8ca5d4fea3fa6e8/linux-riscv32/Dockerfile.in#L42

Shouldn't this be:

```diff
- ENV PKG_CONFIG_PATH /usr/lib/riscv64-unknown-linux-gnu/pkgconfig 
+ ENV PKG_CONFIG_PATH /usr/lib/riscv32-unknown-linux-gnu/pkgconfig 
```

... or does the RISCV32 container actually use the RISCV64 pkgconfig prefix?