### PR TITLE
Fix linux-armv5 typo

### DIFF
--- a/linux-armv5/Dockerfile.in
+++ b/linux-armv5/Dockerfile.in
@@ -38,7 +38,7 @@ ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 COPY Toolchain.cmake ${CROSS_ROOT}/
 ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
 
-ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabihf/
+ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabi/pkgconfig
 
 # Linux kernel cross compilation variables
 ENV PATH ${PATH}:${CROSS_ROOT}/bin


### PR DESCRIPTION
Allow `pkg-config` to find `.pc` files for the appropriate architecture.
* The `Makefile.in` for `linux-armv5` says the following:
   >  This is for ARMv5 "legacy" (armel) devices **which do NOT support hard float VFP instructions (armhf)**

   ... however, the `PKG_CONFIG_PATH` points to a `hf` ("hard float") ABI: `arm-linux-gnueabihf`.  I believe this is a typo.
* The `PKG_CONFIG_PATH` points to the root of `/usr/lib/arm-linux-gnueabihf/`.  I believe this is a second typo.

   ... assuming the intention is to point to a subdirectory which contains `.pc` files, this would be `/usr/lib/arm-linux-gnueabihf/pkgconfig` (or in this case, `/usr/lib/arm-linux-gnueabi/pkgconfig/`).  Example `.pc` file: https://packages.debian.org/bullseye/armel/libhidapi-dev/filelist

   Partially related, I believe this second issue occurs in several dockcross images: https://github.com/search?q=repo%3Adockcross%2Fdockcross%20PKG_CONFIG_PATH&type=code


This issue was originally discovered downstream here: https://github.com/gary-rowe/hid4java/pull/143.  A workaround is to use `export PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabi/pkgconfig/ && ...` in the run command.


