### PR TITLE
spelling fixes in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ set(CMAKE_SYSROOT ${cross_root}/${cross_triple}/sysroot)
 set(CMAKE_CROSSCOMPILING_EMULATOR /usr/bin/qemu-arm64)
 ```
 
-Then ou must change these lines according to the targeted architecture, here **ARM64**:
+Then you must change these lines according to the targeted architecture, here **ARM64**:
 
 ```cmake
 set(CMAKE_SYSTEM_PROCESSOR ARM64)
@@ -174,7 +174,7 @@ ENV ARCH arm64
 #include "common.label-and-env"
 ```
 
-Then ou must change these lines according to the targeted architecture.
+Then you must change these lines according to the targeted architecture.
 
 Here you have to change the value according to the name of the toolchain (./ct-ng show-tuple):
 

--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ The key difference is that [dockbuild](https://github.com/dockbuild/dockbuild#re
 
 ## Build images by yourself
 
-Prebuilt images available on Docker hub are single architecture amd64 images. Those images work evan on different architectures: for example, if you run a dockcross image on Docker running on an Apple M1, the image will run in emulation mode, meaning that it will still work as expected, although it will be slower than running on native hardware (you can expect a factor or 10 or more).
+Prebuilt images available on Docker hub are single architecture amd64 images. Those images work even on different architectures: for example, if you run a dockcross image on Docker running on an Apple M1, the image will run in emulation mode, meaning that it will still work as expected, although it will be slower than running on native hardware (you can expect a factor or 10 or more).
 
 To overcome this limitation, you can build your own images on non-amd64 architectures. To do so, you can use the `Makefile` provided in this repository. For example, to build the `linux-armv7` image, and provided that your Docker hub organization name is `ACME`, you can run:
 


### PR DESCRIPTION
Spelling fixes in the markdown files.

```
ou -> you

evan -> even
```