### PR TITLE
Enable specification of build tool with OCI_EXE, building images for arm64 hosts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,15 @@ jobs:
           submodules: "recursive"
           fetch-depth: 1
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: build
+        env:
+          BUILD_CMD: buildx build --platform linux/amd64,linux/arm64
         run: make base
 
       - name: test

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,13 @@
 # Name of the docker executable
 DOCKER := $(or $(OCI_EXE), docker)
 
+# The build sub-command. Use:
+#
+#   export "BUILD_CMD=buildx build --platform linux/amd64,linux/arm64"
+#
+# to generate multi-platform images.
+BUILD_CMD := $(or $(BUILD_CMD), build)
+
 # Docker organization to pull the images from
 ORG = dockcross
 
@@ -118,8 +125,7 @@ $(GEN_IMAGE_DOCKERFILES) Dockerfile: %Dockerfile: %Dockerfile.in $(DOCKER_COMPOS
 web-wasm: web-wasm/Dockerfile
 	mkdir -p $@/imagefiles && cp -r imagefiles $@/
 	cp -r test web-wasm/
-	$(DOCKER) buildx build -t $(ORG)/web-wasm:$(TAG) \
-		--platform linux/amd64,linux/arm64 \
+	$(DOCKER) $(BUILD_CMD) -t $(ORG)/web-wasm:$(TAG) \
 		-t $(ORG)/web-wasm:latest \
 		--build-arg IMAGE=$(ORG)/web-wasm \
 		--build-arg VERSION=$(TAG) \

--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,7 @@ $(VERBOSE).SILENT: display_images
 
 $(STANDARD_IMAGES): %: %/Dockerfile base
 	mkdir -p $@/imagefiles && cp -r imagefiles $@/
-	$(DOCKER) build -t $(ORG)/$@:latest \
+	$(DOCKER) $(BUILD_CMD) -t $(ORG)/$@:latest \
 		-t $(ORG)/$@:$(TAG) \
 		--build-arg ORG=$(ORG) \
 		--build-arg IMAGE=$(ORG)/$@ \

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,8 @@ $(GEN_IMAGE_DOCKERFILES) Dockerfile: %Dockerfile: %Dockerfile.in $(DOCKER_COMPOS
 web-wasm: web-wasm/Dockerfile
 	mkdir -p $@/imagefiles && cp -r imagefiles $@/
 	cp -r test web-wasm/
-	$(DOCKER) build -t $(ORG)/web-wasm:$(TAG) \
+	$(DOCKER) buildx build -t $(ORG)/web-wasm:$(TAG) \
+		--platform linux/amd64,linux/arm64 \
 		-t $(ORG)/web-wasm:latest \
 		--build-arg IMAGE=$(ORG)/web-wasm \
 		--build-arg VERSION=$(TAG) \

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 #
 
 # Name of the docker executable
-DOCKER := docker
+DOCKER := $(or $(OCI_EXE), docker)
 
 # Docker organization to pull the images from
 ORG = dockcross

--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ manylinux2014-x86.test: manylinux2014-x86
 # base
 #
 base: Dockerfile imagefiles/
-	$(DOCKER) build -t $(ORG)/base:latest \
+	$(DOCKER) $(BUILD_CMD) -t $(ORG)/base:latest \
 		-t $(ORG)/base:$(TAG) \
 		--build-arg IMAGE=$(ORG)/base \
 		--build-arg VCS_URL=`git config --get remote.origin.url` \


### PR DESCRIPTION
Enabling build the dockcross images with `podman`.

Enable building multiple architecture images for both amd64 and arm64. arm64 hosts, e.g. an Apple Silicon mac, can run the amd64, but the emulation is quite slow.