### PR TITLE
linux-armv7a: bump gcc to 12.3.0 and kernel headers to 6.1.35

### DIFF
--- a/linux-armv7a/Dockerfile.in
+++ b/linux-armv7a/Dockerfile.in
@@ -5,8 +5,8 @@ LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 
 # This is for 32-bit ARMv7 Linux
 
-# Crosstool-ng version 2022-05-19
-ENV CT_VERSION crosstool-ng-1.25.0
+# Crosstool-ng version 2024-05-21
+ENV CT_VERSION crosstool-ng-1.26.0
 
 #include "common.crosstool"
 

--- a/linux-armv7a/crosstool-ng.config
+++ b/linux-armv7a/crosstool-ng.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# crosstool-NG 1.25.0.26_db6f703 Configuration
+# crosstool-NG 1.26.0 Configuration
 #
 CT_CONFIGURE_has_static_link=y
 CT_CONFIGURE_has_cxx11=y
@@ -19,15 +19,15 @@ CT_CONFIGURE_has_automake_1_15_or_newer=y
 CT_CONFIGURE_has_gnu_m4_1_4_12_or_newer=y
 CT_CONFIGURE_has_python_3_4_or_newer=y
 CT_CONFIGURE_has_bison_2_7_or_newer=y
+CT_CONFIGURE_has_bison_3_0_4_or_newer=y
 CT_CONFIGURE_has_python=y
-CT_CONFIGURE_has_dtc=y
 CT_CONFIGURE_has_git=y
 CT_CONFIGURE_has_md5sum=y
 CT_CONFIGURE_has_sha1sum=y
 CT_CONFIGURE_has_sha256sum=y
 CT_CONFIGURE_has_sha512sum=y
 CT_CONFIGURE_has_install_with_strip_program=y
-CT_VERSION="1.25.0.26_db6f703"
+CT_VERSION="1.26.0"
 CT_VCHECK=""
 CT_CONFIG_VERSION_ENV="4"
 CT_CONFIG_VERSION_CURRENT="4"
@@ -132,6 +132,7 @@ CT_LOG_FILE_COMPRESS=y
 # CT_ARCH_ARC is not set
 CT_ARCH_ARM=y
 # CT_ARCH_AVR is not set
+# CT_ARCH_BPF is not set
 # CT_ARCH_M68K is not set
 # CT_ARCH_MIPS is not set
 # CT_ARCH_NIOS2 is not set
@@ -158,7 +159,7 @@ CT_ARCH_ARM_MODE_ARM=y
 CT_ARCH_ARM_EABI_FORCE=y
 CT_ARCH_ARM_EABI=y
 CT_ARCH_ARM_TUPLE_USE_EABIHF=y
-CT_ALL_ARCH_CHOICES="ALPHA ARC ARM AVR C6X M68K MICROBLAZE MIPS MOXIE MSP430 NIOS2 POWERPC PRU RISCV S390 SH SPARC X86 XTENSA"
+CT_ALL_ARCH_CHOICES="ALPHA ARC ARM AVR BPF C6X LOONGARCH M68K MICROBLAZE MIPS MOXIE MSP430 NIOS2 POWERPC PRU RISCV S390 SH SPARC X86 XTENSA"
 CT_ARCH_SUFFIX=""
 # CT_OMIT_TARGET_VENDOR is not set
 
@@ -171,6 +172,7 @@ CT_ARCH_SUPPORTS_BOTH_MMU=y
 CT_ARCH_DEFAULT_HAS_MMU=y
 CT_ARCH_USE_MMU=y
 CT_ARCH_SUPPORTS_FLAT_FORMAT=y
+CT_ARCH_SUPPORTS_LIBSANITIZER=y
 CT_ARCH_SUPPORTS_EITHER_ENDIAN=y
 CT_ARCH_DEFAULT_LE=y
 # CT_ARCH_BE is not set
@@ -270,6 +272,13 @@ CT_LINUX_PKG_NAME="linux"
 CT_LINUX_SRC_RELEASE=y
 # CT_LINUX_SRC_DEVEL is not set
 CT_LINUX_PATCH_ORDER="global"
+# CT_LINUX_V_6_4 is not set
+# CT_LINUX_V_6_3 is not set
+# CT_LINUX_V_6_2 is not set
+# CT_LINUX_V_6_1 is not set
+# CT_LINUX_V_6_0 is not set
+# CT_LINUX_V_5_19 is not set
+# CT_LINUX_V_5_18 is not set
 # CT_LINUX_V_5_17 is not set
 # CT_LINUX_V_5_16 is not set
 # CT_LINUX_V_5_15 is not set
@@ -312,6 +321,8 @@ CT_LINUX_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_LINUX_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_LINUX_ARCHIVE_FORMATS=".tar.xz .tar.gz"
 CT_LINUX_SIGNATURE_FORMAT="unpacked/.sign"
+CT_LINUX_5_19_or_older=y
+CT_LINUX_older_than_5_19=y
 CT_LINUX_later_than_5_12=y
 CT_LINUX_5_12_or_later=y
 CT_LINUX_later_than_5_5=y
@@ -359,6 +370,8 @@ CT_BINUTILS_PKG_NAME="binutils"
 CT_BINUTILS_SRC_RELEASE=y
 # CT_BINUTILS_SRC_DEVEL is not set
 CT_BINUTILS_PATCH_ORDER="global"
+# CT_BINUTILS_V_2_40 is not set
+# CT_BINUTILS_V_2_39 is not set
 # CT_BINUTILS_V_2_38 is not set
 # CT_BINUTILS_V_2_37 is not set
 CT_BINUTILS_V_2_36=y
@@ -378,6 +391,8 @@ CT_BINUTILS_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_BINUTILS_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_BINUTILS_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
 CT_BINUTILS_SIGNATURE_FORMAT="packed/.sig"
+CT_BINUTILS_2_39_or_older=y
+CT_BINUTILS_older_than_2_39=y
 CT_BINUTILS_later_than_2_30=y
 CT_BINUTILS_2_30_or_later=y
 CT_BINUTILS_later_than_2_27=y
@@ -428,6 +443,9 @@ CT_GLIBC_PKG_NAME="glibc"
 CT_GLIBC_SRC_RELEASE=y
 # CT_GLIBC_SRC_DEVEL is not set
 CT_GLIBC_PATCH_ORDER="global"
+# CT_GLIBC_V_2_38 is not set
+# CT_GLIBC_V_2_37 is not set
+# CT_GLIBC_V_2_36 is not set
 # CT_GLIBC_V_2_35 is not set
 CT_GLIBC_V_2_34=y
 # CT_GLIBC_V_2_33 is not set
@@ -449,6 +467,12 @@ CT_GLIBC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_GLIBC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_GLIBC_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
 CT_GLIBC_SIGNATURE_FORMAT="packed/.sig"
+CT_GLIBC_2_38_or_older=y
+CT_GLIBC_older_than_2_38=y
+CT_GLIBC_2_37_or_older=y
+CT_GLIBC_older_than_2_37=y
+CT_GLIBC_2_36_or_older=y
+CT_GLIBC_older_than_2_36=y
 CT_GLIBC_2_34_or_later=y
 CT_GLIBC_2_34_or_older=y
 CT_GLIBC_later_than_2_32=y
@@ -488,6 +512,7 @@ CT_GLIBC_HAS_LIBIDN_ADDON=y
 CT_GLIBC_NO_SPARC_V8=y
 CT_GLIBC_EXTRA_CONFIG_ARRAY=""
 CT_GLIBC_CONFIGPARMS=""
+CT_GLIBC_ENABLE_DEBUG=y
 CT_GLIBC_EXTRA_CFLAGS=""
 # CT_GLIBC_DISABLE_VERSIONING is not set
 CT_GLIBC_OLDEST_ABI=""
@@ -505,7 +530,7 @@ CT_GLIBC_SSP_DEFAULT=y
 # CT_GLIBC_SSP_STRONG is not set
 # CT_GLIBC_ENABLE_WERROR is not set
 # CT_GLIBC_ENABLE_COMMON_FLAG is not set
-CT_ALL_LIBC_CHOICES="AVR_LIBC GLIBC MINGW_W64 MOXIEBOX MUSL NEWLIB NONE UCLIBC_NG"
+CT_ALL_LIBC_CHOICES="AVR_LIBC GLIBC MINGW_W64 MOXIEBOX MUSL NEWLIB NONE PICOLIBC UCLIBC_NG"
 CT_LIBC_SUPPORT_THREADS_ANY=y
 CT_LIBC_SUPPORT_THREADS_NATIVE=y
 
@@ -524,6 +549,8 @@ CT_CC_CORE_NEEDED=y
 CT_CC_SUPPORT_CXX=y
 CT_CC_SUPPORT_FORTRAN=y
 CT_CC_SUPPORT_ADA=y
+CT_CC_SUPPORT_D=y
+CT_CC_SUPPORT_JIT=y
 CT_CC_SUPPORT_OBJC=y
 CT_CC_SUPPORT_OBJCXX=y
 CT_CC_SUPPORT_GOLANG=y
@@ -538,11 +565,13 @@ CT_CC_GCC_SHOW=y
 CT_CC_GCC_PKG_KSYM="GCC"
 CT_GCC_DIR_NAME="gcc"
 CT_GCC_USE_GNU=y
+# CT_GCC_USE_ORACLE is not set
 CT_GCC_USE="GCC"
 CT_GCC_PKG_NAME="gcc"
 CT_GCC_SRC_RELEASE=y
 # CT_GCC_SRC_DEVEL is not set
 CT_GCC_PATCH_ORDER="global"
+# CT_GCC_V_13 is not set
 # CT_GCC_V_12 is not set
 CT_GCC_V_11=y
 # CT_GCC_V_10 is not set
@@ -550,12 +579,14 @@ CT_GCC_V_11=y
 # CT_GCC_V_8 is not set
 # CT_GCC_V_7 is not set
 # CT_GCC_V_6 is not set
-CT_GCC_VERSION="11.3.0"
+CT_GCC_VERSION="11.4.0"
 CT_GCC_MIRRORS="$(CT_Mirrors GNU gcc/gcc-${CT_GCC_VERSION}) $(CT_Mirrors sourceware gcc/releases/gcc-${CT_GCC_VERSION})"
 CT_GCC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_GCC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_GCC_ARCHIVE_FORMATS=".tar.xz .tar.gz"
 CT_GCC_SIGNATURE_FORMAT=""
+CT_GCC_13_or_older=y
+CT_GCC_older_than_13=y
 CT_GCC_12_or_older=y
 CT_GCC_older_than_12=y
 CT_GCC_later_than_11=y
@@ -597,12 +628,14 @@ CT_CC_GCC_LTO_ZSTD=m
 #
 # Settings for libraries running on target
 #
+# CT_CC_GCC_ENABLE_DEFAULT_PIE is not set
 CT_CC_GCC_ENABLE_TARGET_OPTSPACE=y
 CT_CC_GCC_LIBMUDFLAP=y
 CT_CC_GCC_LIBGOMP=y
 CT_CC_GCC_LIBSSP=m
 CT_CC_GCC_LIBQUADMATH=y
 CT_CC_GCC_LIBSANITIZER=y
+CT_CC_GCC_LIBSTDCXX_VERBOSE=m
 
 #
 # Misc. obscure options.
@@ -643,6 +676,7 @@ CT_GDB_PKG_NAME="gdb"
 CT_GDB_SRC_RELEASE=y
 # CT_GDB_SRC_DEVEL is not set
 CT_GDB_PATCH_ORDER="global"
+# CT_GDB_V_13 is not set
 CT_GDB_V_12=y
 # CT_GDB_V_11 is not set
 # CT_GDB_V_10 is not set
@@ -654,6 +688,8 @@ CT_GDB_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_GDB_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_GDB_ARCHIVE_FORMATS=".tar.xz .tar.gz"
 CT_GDB_SIGNATURE_FORMAT=""
+CT_GDB_13_or_older=y
+CT_GDB_older_than_13=y
 CT_GDB_later_than_12=y
 CT_GDB_12_or_later=y
 CT_GDB_later_than_11=y
@@ -703,8 +739,8 @@ CT_EXPAT_PKG_NAME="expat"
 CT_EXPAT_SRC_RELEASE=y
 # CT_EXPAT_SRC_DEVEL is not set
 CT_EXPAT_PATCH_ORDER="global"
-CT_EXPAT_V_2_4=y
-CT_EXPAT_VERSION="2.4.1"
+CT_EXPAT_V_2_5=y
+CT_EXPAT_VERSION="2.5.0"
 CT_EXPAT_MIRRORS="http://downloads.sourceforge.net/project/expat/expat/${CT_EXPAT_VERSION} https://github.com/libexpat/libexpat/releases/download/R_${CT_EXPAT_VERSION//./_}"
 CT_EXPAT_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_EXPAT_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
@@ -750,6 +786,8 @@ CT_ISL_PKG_NAME="isl"
 CT_ISL_SRC_RELEASE=y
 # CT_ISL_SRC_DEVEL is not set
 CT_ISL_PATCH_ORDER="global"
+# CT_ISL_V_0_26 is not set
+# CT_ISL_V_0_25 is not set
 CT_ISL_V_0_24=y
 # CT_ISL_V_0_23 is not set
 # CT_ISL_V_0_22 is not set
@@ -794,10 +832,8 @@ CT_MPC_SRC_RELEASE=y
 # CT_MPC_SRC_DEVEL is not set
 CT_MPC_PATCH_ORDER="global"
 CT_MPC_V_1_2=y
-# CT_MPC_V_1_1 is not set
-# CT_MPC_V_1_0 is not set
 CT_MPC_VERSION="1.2.1"
-CT_MPC_MIRRORS="http://www.multiprecision.org/downloads $(CT_Mirrors GNU mpc)"
+CT_MPC_MIRRORS="https://www.multiprecision.org/downloads $(CT_Mirrors GNU mpc)"
 CT_MPC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_MPC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_MPC_ARCHIVE_FORMATS=".tar.gz"
@@ -811,11 +847,9 @@ CT_MPFR_PKG_NAME="mpfr"
 CT_MPFR_SRC_RELEASE=y
 # CT_MPFR_SRC_DEVEL is not set
 CT_MPFR_PATCH_ORDER="global"
-CT_MPFR_V_4_1=y
-# CT_MPFR_V_4_0 is not set
-# CT_MPFR_V_3_1 is not set
-CT_MPFR_VERSION="4.1.0"
-CT_MPFR_MIRRORS="http://www.mpfr.org/mpfr-${CT_MPFR_VERSION} $(CT_Mirrors GNU mpfr)"
+CT_MPFR_V_4_2=y
+CT_MPFR_VERSION="4.2.1"
+CT_MPFR_MIRRORS="https://www.mpfr.org/mpfr-${CT_MPFR_VERSION} $(CT_Mirrors GNU mpfr)"
 CT_MPFR_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_MPFR_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_MPFR_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz .zip"
@@ -829,6 +863,7 @@ CT_NCURSES_PKG_NAME="ncurses"
 CT_NCURSES_SRC_RELEASE=y
 # CT_NCURSES_SRC_DEVEL is not set
 CT_NCURSES_PATCH_ORDER="global"
+# CT_NCURSES_V_6_4 is not set
 CT_NCURSES_V_6_2=y
 # CT_NCURSES_V_6_1 is not set
 # CT_NCURSES_V_6_0 is not set
@@ -852,14 +887,29 @@ CT_ZLIB_PKG_NAME="zlib"
 CT_ZLIB_SRC_RELEASE=y
 # CT_ZLIB_SRC_DEVEL is not set
 CT_ZLIB_PATCH_ORDER="global"
-CT_ZLIB_V_1_2_12=y
-CT_ZLIB_VERSION="1.2.12"
-CT_ZLIB_MIRRORS="http://downloads.sourceforge.net/project/libpng/zlib/${CT_ZLIB_VERSION} https://www.zlib.net/ https://www.zlib.net/fossils"
+CT_ZLIB_V_1_2_13=y
+CT_ZLIB_VERSION="1.2.13"
+CT_ZLIB_MIRRORS="https://github.com/madler/zlib/releases/download/v${CT_ZLIB_VERSION} https://www.zlib.net/"
 CT_ZLIB_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ZLIB_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ZLIB_ARCHIVE_FORMATS=".tar.xz .tar.gz"
 CT_ZLIB_SIGNATURE_FORMAT="packed/.asc"
-CT_ALL_COMP_LIBS_CHOICES="CLOOG EXPAT GETTEXT GMP GNUPRUMCU ISL LIBELF LIBICONV MPC MPFR NCURSES NEWLIB_NANO PICOLIBC ZLIB"
+CT_COMP_LIBS_ZSTD=y
+CT_COMP_LIBS_ZSTD_PKG_KSYM="ZSTD"
+CT_ZSTD_DIR_NAME="zstd"
+CT_ZSTD_PKG_NAME="zstd"
+CT_ZSTD_SRC_RELEASE=y
+# CT_ZSTD_SRC_DEVEL is not set
+CT_ZSTD_PATCH_ORDER="global"
+CT_ZSTD_V_1_5_5=y
+# CT_ZSTD_V_1_5_2 is not set
+CT_ZSTD_VERSION="1.5.5"
+CT_ZSTD_MIRRORS="https://github.com/facebook/zstd/releases/download/v${CT_ZSTD_VERSION} https://www.zstd.net/"
+CT_ZSTD_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_ZSTD_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_ZSTD_ARCHIVE_FORMATS=".tar.gz"
+CT_ZSTD_SIGNATURE_FORMAT="packed/.sig"
+CT_ALL_COMP_LIBS_CHOICES="CLOOG EXPAT GETTEXT GMP GNUPRUMCU ISL LIBELF LIBICONV MPC MPFR NCURSES NEWLIB_NANO PICOLIBC ZLIB ZSTD"
 CT_LIBICONV_NEEDED=y
 CT_GETTEXT_NEEDED=y
 CT_GMP_NEEDED=y
@@ -869,6 +919,7 @@ CT_MPC_NEEDED=y
 CT_EXPAT_NEEDED=y
 CT_NCURSES_NEEDED=y
 CT_ZLIB_NEEDED=y
+CT_ZSTD_NEEDED=y
 CT_LIBICONV=y
 CT_GETTEXT=y
 CT_GMP=y
@@ -878,6 +929,7 @@ CT_MPC=y
 CT_EXPAT=y
 CT_NCURSES=y
 CT_ZLIB=y
+CT_ZSTD=y
 # end of Companion libraries
 
 #

--- a/linux-armv7a/crosstool-ng.config
+++ b/linux-armv7a/crosstool-ng.config
@@ -275,14 +275,14 @@ CT_LINUX_PATCH_ORDER="global"
 # CT_LINUX_V_6_4 is not set
 # CT_LINUX_V_6_3 is not set
 # CT_LINUX_V_6_2 is not set
-# CT_LINUX_V_6_1 is not set
+CT_LINUX_V_6_1=y
 # CT_LINUX_V_6_0 is not set
 # CT_LINUX_V_5_19 is not set
 # CT_LINUX_V_5_18 is not set
 # CT_LINUX_V_5_17 is not set
 # CT_LINUX_V_5_16 is not set
 # CT_LINUX_V_5_15 is not set
-CT_LINUX_V_5_14=y
+# CT_LINUX_V_5_14 is not set
 # CT_LINUX_V_5_13 is not set
 # CT_LINUX_V_5_12 is not set
 # CT_LINUX_V_5_11 is not set
@@ -315,14 +315,14 @@ CT_LINUX_V_5_14=y
 # CT_LINUX_V_3_10 is not set
 # CT_LINUX_V_3_4 is not set
 # CT_LINUX_V_3_2 is not set
-CT_LINUX_VERSION="5.14.18"
+CT_LINUX_VERSION="6.1.35"
 CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION})"
 CT_LINUX_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_LINUX_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_LINUX_ARCHIVE_FORMATS=".tar.xz .tar.gz"
 CT_LINUX_SIGNATURE_FORMAT="unpacked/.sign"
-CT_LINUX_5_19_or_older=y
-CT_LINUX_older_than_5_19=y
+CT_LINUX_later_than_5_19=y
+CT_LINUX_5_19_or_later=y
 CT_LINUX_later_than_5_12=y
 CT_LINUX_5_12_or_later=y
 CT_LINUX_later_than_5_5=y

--- a/linux-armv7a/crosstool-ng.config
+++ b/linux-armv7a/crosstool-ng.config
@@ -572,14 +572,14 @@ CT_GCC_SRC_RELEASE=y
 # CT_GCC_SRC_DEVEL is not set
 CT_GCC_PATCH_ORDER="global"
 # CT_GCC_V_13 is not set
-# CT_GCC_V_12 is not set
-CT_GCC_V_11=y
+CT_GCC_V_12=y
+# CT_GCC_V_11 is not set
 # CT_GCC_V_10 is not set
 # CT_GCC_V_9 is not set
 # CT_GCC_V_8 is not set
 # CT_GCC_V_7 is not set
 # CT_GCC_V_6 is not set
-CT_GCC_VERSION="11.4.0"
+CT_GCC_VERSION="12.3.0"
 CT_GCC_MIRRORS="$(CT_Mirrors GNU gcc/gcc-${CT_GCC_VERSION}) $(CT_Mirrors sourceware gcc/releases/gcc-${CT_GCC_VERSION})"
 CT_GCC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_GCC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
@@ -587,8 +587,8 @@ CT_GCC_ARCHIVE_FORMATS=".tar.xz .tar.gz"
 CT_GCC_SIGNATURE_FORMAT=""
 CT_GCC_13_or_older=y
 CT_GCC_older_than_13=y
-CT_GCC_12_or_older=y
-CT_GCC_older_than_12=y
+CT_GCC_later_than_12=y
+CT_GCC_12_or_later=y
 CT_GCC_later_than_11=y
 CT_GCC_11_or_later=y
 CT_GCC_later_than_10=y


### PR DESCRIPTION
Updates crosstool, gcc and kernel headers