### PR TITLE
Correct the qemu download URLs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1098,6 +1098,8 @@ jobs:
         run: xz -d -k < ./cache/base.tar.xz | docker import - dockcross/base:latest
 
       - name: build
+        env:
+          BUILD_CMD: build --cache-from type=gha --cache-to type=gha,mode=max
         run: make ${{ matrix.arch_name.image }}
 
       - name: basic test

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ web-wasi-threads.test: web-wasi-threads
 #
 # manylinux2014-aarch64
 #
-manylinux2014-aarch64: manylinux2014-aarch64/Dockerfile
+manylinux2014-aarch64: manylinux2014-aarch64/Dockerfile manylinux2014-x64
 	@# Register qemu
 	docker run --rm --privileged hypriot/qemu-register
 	@# Get libstdc++ from quay.io/pypa/manylinux2014_aarch64 container

--- a/linux-m68k-uclibc/Dockerfile.in
+++ b/linux-m68k-uclibc/Dockerfile.in
@@ -15,7 +15,7 @@ ENV CROSS_TRIPLE m68k-unknown-uclinux-uclibc
 WORKDIR /usr/src
 
 RUN apt-get install -y libglib2.0-dev zlib1g-dev libpixman-1-dev && \
-  curl -L http://wiki.qemu-project.org/download/qemu-${QEMU_VERSION}.tar.bz2 | tar xj && \
+  curl -L https://download.qemu.org/qemu-${QEMU_VERSION}.tar.bz2 | tar xj && \
   cd qemu-${QEMU_VERSION} && \
   ./configure --target-list=m68k-softmmu --prefix=/usr && \
   make -j$(nproc) && \

--- a/linux-ppc64le-lts/Dockerfile.in
+++ b/linux-ppc64le-lts/Dockerfile.in
@@ -15,7 +15,7 @@ ENV CROSS_TRIPLE powerpc64le-unknown-linux-gnu
 WORKDIR /usr/src
 
 RUN apt-get install -y libglib2.0-dev zlib1g-dev libpixman-1-dev && \
-  curl -L http://wiki.qemu-project.org/download/qemu-${QEMU_VERSION}.tar.bz2 | tar xj && \
+  curl -L https://download.qemu.org/qemu-${QEMU_VERSION}.tar.bz2 | tar xj && \
   cd qemu-${QEMU_VERSION} && \
   ./configure --target-list=ppc64le-linux-user --prefix=/usr && \
   make -j$(nproc) && \

--- a/linux-ppc64le/Dockerfile.in
+++ b/linux-ppc64le/Dockerfile.in
@@ -15,7 +15,7 @@ ENV CROSS_TRIPLE powerpc64le-unknown-linux-gnu
 WORKDIR /usr/src
 
 RUN apt-get install -y libglib2.0-dev zlib1g-dev libpixman-1-dev && \
-  curl -L http://wiki.qemu-project.org/download/qemu-${QEMU_VERSION}.tar.bz2 | tar xj && \
+  curl -L https://download.qemu.org/qemu-${QEMU_VERSION}.tar.bz2 | tar xj && \
   cd qemu-${QEMU_VERSION} && \
   ./configure --target-list=ppc64le-linux-user --prefix=/usr && \
   make -j$(nproc) && \

--- a/linux-riscv32/Dockerfile.in
+++ b/linux-riscv32/Dockerfile.in
@@ -15,7 +15,7 @@ ENV CROSS_TRIPLE riscv32-unknown-linux-gnu
 WORKDIR /usr/src
 
 RUN apt-get install -y libglib2.0-dev zlib1g-dev libpixman-1-dev && \
-  curl -L http://wiki.qemu-project.org/download/qemu-${QEMU_VERSION}.tar.bz2 | tar xj && \
+  curl -L https://download.qemu.org/qemu-${QEMU_VERSION}.tar.bz2 | tar xj && \
   cd qemu-${QEMU_VERSION} && \
   ./configure --target-list=riscv32-linux-user --prefix=/usr && \
   make -j$(nproc) && \

--- a/linux-riscv64/Dockerfile.in
+++ b/linux-riscv64/Dockerfile.in
@@ -15,7 +15,7 @@ ENV CROSS_TRIPLE riscv64-unknown-linux-gnu
 WORKDIR /usr/src
 
 RUN apt-get install -y libglib2.0-dev zlib1g-dev libpixman-1-dev && \
-  curl -L http://wiki.qemu-project.org/download/qemu-${QEMU_VERSION}.tar.bz2 | tar xj && \
+  curl -L https://download.qemu.org/qemu-${QEMU_VERSION}.tar.bz2 | tar xj && \
   cd qemu-${QEMU_VERSION} && \
   ./configure --target-list=riscv64-linux-user --prefix=/usr && \
   make -j$(nproc) && \

--- a/linux-xtensa-uclibc/Dockerfile.in
+++ b/linux-xtensa-uclibc/Dockerfile.in
@@ -15,7 +15,7 @@ ENV CROSS_TRIPLE xtensa-fsf-linux-uclibc
 WORKDIR /usr/src
 
 RUN apt-get install -y libglib2.0-dev zlib1g-dev libpixman-1-dev && \
-  curl -L http://wiki.qemu-project.org/download/qemu-${QEMU_VERSION}.tar.bz2 | tar xj && \
+  curl -L https://download.qemu.org/qemu-${QEMU_VERSION}.tar.bz2 | tar xj && \
   cd qemu-${QEMU_VERSION} && \
   ./configure --target-list=xtensa-linux-user --prefix=/usr && \
   make -j$(nproc) && \

--- a/manylinux2014-x64/Dockerfile.in
+++ b/manylinux2014-x64/Dockerfile.in
@@ -1,5 +1,5 @@
 # Recent versions address yum functionality
-FROM quay.io/pypa/manylinux2014_x86_64:2023-08-27-bd7ad21
+FROM quay.io/pypa/manylinux2014_x86_64:2024-07-20-e0def9a
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/manylinux2014-x86/Dockerfile.in
+++ b/manylinux2014-x86/Dockerfile.in
@@ -1,5 +1,5 @@
 # Recent versions address yum functionality
-FROM quay.io/pypa/manylinux2014_i686:2023-08-27-bd7ad21 
+FROM quay.io/pypa/manylinux2014_i686:2024-07-20-e0def9a  
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 

--- a/manylinux_2_28-x64/Dockerfile.in
+++ b/manylinux_2_28-x64/Dockerfile.in
@@ -1,5 +1,5 @@
 # Recent versions address yum functionality
-FROM quay.io/pypa/manylinux_2_28_x86_64:2022-11-28-5d13db4
+FROM quay.io/pypa/manylinux_2_28_x86_64:2024-07-20-e0def9a
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"
 


### PR DESCRIPTION
It seems that wiki.qemu-project.org is not available anymore and downloads are now on download.qemu.org.

This is something I noticed when doing a full local build in preparation to work on #838.