### PR TITLE
add ccache to common debian container

### DIFF
--- a/common/common.debian
+++ b/common/common.debian
@@ -11,6 +11,7 @@ RUN \
     build-essential \
     bzip2 \
     ca-certificates \
+    ccache \
     curl \
     dirmngr \
     file \


### PR DESCRIPTION
This PR adds ccache to the debian based containers.
It should work as expected but some testing is probably required.

Resolves #845.