### PR TITLE
emscripten 3 1 64

### DIFF
--- a/test/run.py
+++ b/test/run.py
@@ -44,7 +44,7 @@ def test_cmake_build_system(build_dir, language, source, emulator, linker_flags,
     print('Building ' + source + ' with CMake...')
 
     with open('CMakeLists.txt', 'w') as fp:
-        fp.write('cmake_minimum_required(VERSION 3.0)\n')
+        fp.write('cmake_minimum_required(VERSION 3.16)\n')
         fp.write('project(test-compiler)\n')
         fp.write('add_executable(a.out ' + os.path.basename(source) + ')\n')
         if emulator:

--- a/web-wasm/Dockerfile.in
+++ b/web-wasm/Dockerfile.in
@@ -1,4 +1,4 @@
-ARG DOCKER_IMAGE_VERSION=3.1.60
+ARG DOCKER_IMAGE_VERSION=3.1.64
 FROM emscripten/emsdk:$DOCKER_IMAGE_VERSION
 
 LABEL maintainer="Matt McCormick matt.mccormick@kitware.com"


### PR DESCRIPTION
- web-wasm: bump emscripten to 3.1.64
- test: bump cmake_minimum_required to 3.16
