### PR TITLE
wasi: fix threads option specification for wasmtime

### DIFF
--- a/imagefiles/wasmtime-pwd-threads.sh
+++ b/imagefiles/wasmtime-pwd-threads.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # Mount the PWD and the /work mount dir to enable access in try_run commands
-exec ${WASMTIME_HOME}/bin/wasmtime -S threads=y run --dir=. --dir=$PWD --dir=/work/ "$@"
+exec ${WASMTIME_HOME}/bin/wasmtime run -W threads=y -S threads=y,cli=y --dir=. --dir=$PWD --dir=/work/ "$@"


### PR DESCRIPTION
In recent wasmtime, `-S` flags need to come after `run`.

Also add `-W threads=y` following the wasmtime test suite,

- https://github.com/bytecodealliance/wasmtime/blob/fc3c868b13bccf5d7ed26de4cfd1a2dc4c689360/tests/all/cli_tests.rs#L580-L581

Also explicity enable the `cli` feature because this is used for CMake
try_run.
