### PR TITLE
Fix new docker env syntax

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,7 @@ LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 # This is for 64-bit ARM Linux machine
 
 # Crosstool-ng crosstool-ng-1.25.0 2022-05-13
-ENV CT_VERSION crosstool-ng-1.25.0
+ENV CT_VERSION=crosstool-ng-1.25.0
 
 #include "common.crosstool"
 
@@ -147,9 +147,9 @@ RUN apt-get update \
 && apt-get clean --yes
 
 # The CROSS_TRIPLE is a configured alias of the "aarch64-unknown-linux-gnu" target.
-ENV CROSS_TRIPLE aarch64-unknown-linux-gnu
+ENV CROSS_TRIPLE=aarch64-unknown-linux-gnu
 
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -158,18 +158,18 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
-ENV PKG_CONFIG_PATH /usr/lib/aarch64-linux-gnu/pkgconfig
+ENV PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH arm64
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=arm64
 
 #include "common.label-and-env"
 ```
@@ -179,15 +179,15 @@ Then you must change these lines according to the targeted architecture.
 Here you have to change the value according to the name of the toolchain (./ct-ng show-tuple):
 
 ```docker
-ENV CROSS_TRIPLE aarch64-unknown-linux-gnu
+ENV CROSS_TRIPLE=aarch64-unknown-linux-gnu
 ```
 
 These lines also need to be changed:
 
 ```docker
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
-ENV PKG_CONFIG_PATH /usr/lib/aarch64-linux-gnu/pkgconfig
-ENV ARCH arm64
+ENV PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
+ENV ARCH=arm64
 ```
 
 Once this part is finished, there must be 3 files in the `linux-arm64` folder:

--- a/README.md
+++ b/README.md
@@ -569,7 +569,7 @@ An example Dockerfile would be:
 ```
 FROM dockcross/linux-armv7
 
-ENV DEFAULT_DOCKCROSS_IMAGE my_cool_image
+ENV DEFAULT_DOCKCROSS_IMAGE=my_cool_image
 RUN apt-get install -y nano
 ```
 

--- a/android-arm/Dockerfile.in
+++ b/android-arm/Dockerfile.in
@@ -17,8 +17,8 @@ ENV AS=${CROSS_ROOT}/bin/llvm-as \
     CXX=${CROSS_ROOT}/bin/clang++ \
     LD=${CROSS_ROOT}/bin/ld
 
-ENV ANDROID_NDK_REVISION 25b
-ENV ANDROID_API 23
+ENV ANDROID_NDK_REVISION=25b
+ENV ANDROID_API=23
 
 RUN mkdir -p /build && \
     cd /build && \
@@ -42,6 +42,6 @@ COPY config.toml /root/.cargo/
 
 # Prepare CMake
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
 #include "common.label-and-env"

--- a/android-arm64/Dockerfile.in
+++ b/android-arm64/Dockerfile.in
@@ -21,8 +21,8 @@ ENV AS=${CROSS_ROOT}/bin/llvm-as \
     CXX=${CROSS_ROOT}/bin/clang++ \
     LD=${CROSS_ROOT}/bin/ld
 
-ENV ANDROID_NDK_REVISION 25b
-ENV ANDROID_API 23
+ENV ANDROID_NDK_REVISION=25b
+ENV ANDROID_API=23
 
 RUN mkdir -p /build && \
     cd /build && \
@@ -46,6 +46,6 @@ COPY config.toml /root/.cargo/
 
 # Prepare CMake
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
 #include "common.label-and-env"

--- a/android-x86/Dockerfile
+++ b/android-x86/Dockerfile
@@ -11,8 +11,8 @@ ENV AS=${CROSS_ROOT}/bin/llvm-as \
     CXX=${CROSS_ROOT}/bin/clang++ \
     LD=${CROSS_ROOT}/bin/ld
 
-ENV ANDROID_NDK_REVISION 25b
-ENV ANDROID_API 23
+ENV ANDROID_NDK_REVISION=25b
+ENV ANDROID_API=23
 
 RUN mkdir -p /build && \
     cd /build && \
@@ -36,7 +36,7 @@ COPY config.toml /root/.cargo/
 
 # Prepare CMake
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
@@ -50,4 +50,4 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.vcs-url=$VCS_URL \
       org.label-schema.schema-version="1.0"
-ENV DEFAULT_DOCKCROSS_IMAGE ${IMAGE}:${VERSION}
+ENV DEFAULT_DOCKCROSS_IMAGE=${IMAGE}:${VERSION}

--- a/android-x86_64/Dockerfile
+++ b/android-x86_64/Dockerfile
@@ -11,8 +11,8 @@ ENV AS=${CROSS_ROOT}/bin/llvm-as \
     CXX=${CROSS_ROOT}/bin/clang++ \
     LD=${CROSS_ROOT}/bin/ld
 
-ENV ANDROID_NDK_REVISION 25b
-ENV ANDROID_API 23
+ENV ANDROID_NDK_REVISION=25b
+ENV ANDROID_API=23
 
 RUN mkdir -p /build && \
     cd /build && \
@@ -36,7 +36,7 @@ COPY config.toml /root/.cargo/
 
 # Prepare CMake
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
@@ -50,4 +50,4 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.vcs-url=$VCS_URL \
       org.label-schema.schema-version="1.0"
-ENV DEFAULT_DOCKCROSS_IMAGE ${IMAGE}:${VERSION}
+ENV DEFAULT_DOCKCROSS_IMAGE=${IMAGE}:${VERSION}

--- a/bare-armv7emhf-nano_newlib/Dockerfile.in
+++ b/bare-armv7emhf-nano_newlib/Dockerfile.in
@@ -6,13 +6,13 @@ LABEL maintainer="Chen Tao t.clydechen@gmail.com"
 # This is for armv7e-m+fp bare metal
 
 # Crosstool-ng version 1.25.0
-ENV CT_VERSION 8fa98eeeff9bc53478d97ef722f366fea151ae64
+ENV CT_VERSION=8fa98eeeff9bc53478d97ef722f366fea151ae64
 
 #include "common.crosstool"
 
-ENV CROSS_TRIPLE arm-none-eabi
+ENV CROSS_TRIPLE=arm-none-eabi
 
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -23,13 +23,13 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     OBJCOPY=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-objcopy
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
-ENV PKG_CONFIG_PATH /usr/lib/arm-none-eabi/pkgconfig
+ENV PKG_CONFIG_PATH=/usr/lib/arm-none-eabi/pkgconfig
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH arm
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=arm
 
 #include "common.label-and-env"

--- a/common/common.windows
+++ b/common/common.windows
@@ -9,7 +9,7 @@
 #
 # For example:
 #
-#  ENV WINEARCH win64
+#  ENV WINEARCH=win64
 #  ARG MXE_TARGET_ARCH=x86_64
 #  ARG MXE_TARGET_THREAD=
 #  ARG MXE_TARGET_LINK=shared
@@ -18,7 +18,7 @@
 # mxe master 2024-07-27
 ARG MXE_GIT_TAG=9f349e0de62a4a68bfc0f13d835a6c685dae9daa
 
-ENV CMAKE_TOOLCHAIN_FILE /usr/src/mxe/usr/${MXE_TARGET_ARCH}-w64-mingw32.${MXE_TARGET_LINK}${MXE_TARGET_THREAD}/share/cmake/mxe-conf.cmake
+ENV CMAKE_TOOLCHAIN_FILE=/usr/src/mxe/usr/${MXE_TARGET_ARCH}-w64-mingw32.${MXE_TARGET_LINK}${MXE_TARGET_THREAD}/share/cmake/mxe-conf.cmake
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -125,8 +125,8 @@ RUN \
   #
   rm -rf /tmp/wine-*
 
-ENV PATH ${PATH}:/usr/src/mxe/usr/bin
-ENV CROSS_TRIPLE ${MXE_TARGET_ARCH}-w64-mingw32.${MXE_TARGET_LINK}${MXE_TARGET_THREAD}
+ENV PATH=${PATH}:/usr/src/mxe/usr/bin
+ENV CROSS_TRIPLE=${MXE_TARGET_ARCH}-w64-mingw32.${MXE_TARGET_LINK}${MXE_TARGET_THREAD}
 ENV AS=/usr/src/mxe/usr/bin/${CROSS_TRIPLE}-as \
     AR=/usr/src/mxe/usr/bin/${CROSS_TRIPLE}-ar \
     CC=/usr/src/mxe/usr/bin/${CROSS_TRIPLE}-gcc \

--- a/linux-arm64-full/Dockerfile.in
+++ b/linux-arm64-full/Dockerfile.in
@@ -7,7 +7,7 @@ LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
 # Buildroot version
 # buildroot master 2021-09-20
-ENV BR_VERSION d4877e6f88d5eea54dc74b855556ffc0dd3f399f
+ENV BR_VERSION=d4877e6f88d5eea54dc74b855556ffc0dd3f399f
 
 #include "common.buildroot"
 
@@ -19,8 +19,8 @@ RUN apt-get update \
 && apt-get clean --yes
 
 # The CROSS_TRIPLE is a configured alias of the "aarch64-buildroot-linux-gnu" target.
-ENV CROSS_TRIPLE aarch64-buildroot-linux-gnu
-ENV CROSS_ROOT /buildroot
+ENV CROSS_TRIPLE=aarch64-buildroot-linux-gnu
+ENV CROSS_ROOT=/buildroot
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -29,17 +29,17 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
-#ENV PKG_CONFIG_PATH /usr/lib/aarch64-linux-gnu/pkgconfig
+#ENV PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH arm64
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=arm64
 
 #include "common.label-and-env"

--- a/linux-arm64-lts/Dockerfile.in
+++ b/linux-arm64-lts/Dockerfile.in
@@ -4,7 +4,7 @@ FROM ${ORG}/base:latest
 # This is for 64-bit ARM Linux machine (Ubuntu 18.04 or Debian 9 mini)
 
 # Crosstool-ng version 2022-05-19
-ENV CT_VERSION crosstool-ng-1.25.0
+ENV CT_VERSION=crosstool-ng-1.25.0
 
 #include "common.crosstool"
 
@@ -16,9 +16,9 @@ RUN apt-get update \
 && apt-get clean --yes
 
 # The CROSS_TRIPLE is a configured alias of the "aarch64-unknown-linux-gnu" target.
-ENV CROSS_TRIPLE aarch64-unknown-linux-gnu
+ENV CROSS_TRIPLE=aarch64-unknown-linux-gnu
 
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -27,17 +27,17 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
-ENV PKG_CONFIG_PATH /usr/lib/aarch64-linux-gnu/pkgconfig
+ENV PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH arm64
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=arm64
 
 #include "common.label-and-env"

--- a/linux-arm64-musl/Dockerfile.in
+++ b/linux-arm64-musl/Dockerfile.in
@@ -1,9 +1,9 @@
 ARG ORG=dockcross
 FROM ${ORG}/base:latest
 
-ENV XCC_PREFIX /usr/xcc
-ENV CROSS_TRIPLE aarch64-linux-musl
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}-cross
+ENV XCC_PREFIX=/usr/xcc
+ENV CROSS_TRIPLE=aarch64-linux-musl
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}-cross
 
 RUN mkdir -p ${XCC_PREFIX}
 RUN curl --max-time 15 --retry 5 -LO http://musl.cc/${CROSS_TRIPLE}-cross.tgz
@@ -18,12 +18,12 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH arm64
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=arm64
 
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
@@ -37,4 +37,4 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.vcs-url=$VCS_URL \
       org.label-schema.schema-version="1.0"
-ENV DEFAULT_DOCKCROSS_IMAGE ${IMAGE}:${VERSION}
+ENV DEFAULT_DOCKCROSS_IMAGE=${IMAGE}:${VERSION}

--- a/linux-armv5-musl/Dockerfile.in
+++ b/linux-armv5-musl/Dockerfile.in
@@ -8,7 +8,7 @@ LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 # musleabi as default glibc
 
 # Crosstool-ng version 2022-05-19
-ENV CT_VERSION crosstool-ng-1.25.0
+ENV CT_VERSION=crosstool-ng-1.25.0
 
 #include "common.crosstool"
 
@@ -20,8 +20,8 @@ RUN apt-get update \
 && apt-get clean --yes
 
 # The CROSS_TRIPLE is a configured alias of the "armv5-unknown-linux-musleabi" target.
-ENV CROSS_TRIPLE armv5-unknown-linux-musleabi
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV CROSS_TRIPLE=armv5-unknown-linux-musleabi
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -30,17 +30,17 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
-ENV PKG_CONFIG_PATH /usr/lib/arm-linux-musleabihf/
+ENV PKG_CONFIG_PATH=/usr/lib/arm-linux-musleabihf/
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH arm
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=arm
 
 #include "common.label-and-env"

--- a/linux-armv5-uclibc/Dockerfile.in
+++ b/linux-armv5-uclibc/Dockerfile.in
@@ -4,7 +4,7 @@ FROM ${ORG}/base:latest
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
 # Crosstool-ng version 2022-05-19
-ENV CT_VERSION crosstool-ng-1.25.0
+ENV CT_VERSION=crosstool-ng-1.25.0
 
 # This is for compiling binaries for arm routers with uclibc (e.g ddwrt, asuswrt)
 #include "common.crosstool"
@@ -16,8 +16,8 @@ RUN apt-get update \
   qemu-user-static \
 && apt-get clean --yes
 
-ENV CROSS_TRIPLE arm-unknown-linux-uclibcgnueabi
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV CROSS_TRIPLE=arm-unknown-linux-uclibcgnueabi
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -26,17 +26,17 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 COPY Toolchain.cmake /usr/lib/${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE /usr/lib/${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=/usr/lib/${CROSS_ROOT}/Toolchain.cmake
 
-ENV PKG_CONFIG_PATH /usr/lib/{CROSS_ROOT}/pkgconfig/
+ENV PKG_CONFIG_PATH=/usr/lib/{CROSS_ROOT}/pkgconfig/
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH arm
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=arm
 
 #include "common.label-and-env"

--- a/linux-armv5/Dockerfile.in
+++ b/linux-armv5/Dockerfile.in
@@ -7,7 +7,7 @@ LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 # VFP instructions (armhf).
 
 # Crosstool-ng version 2022-05-19
-ENV CT_VERSION crosstool-ng-1.25.0
+ENV CT_VERSION=crosstool-ng-1.25.0
 
 #include "common.crosstool"
 
@@ -22,8 +22,8 @@ RUN apt-get update \
 
 
 # The CROSS_TRIPLE is a configured alias of the "aarch64-unknown-linux-gnueabi" target.
-ENV CROSS_TRIPLE armv5-unknown-linux-gnueabi
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV CROSS_TRIPLE=armv5-unknown-linux-gnueabi
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -32,17 +32,17 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
-ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabi/pkgconfig
+ENV PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabi/pkgconfig
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH arm
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=arm
 
 #include "common.label-and-env"

--- a/linux-armv6-lts/Dockerfile.in
+++ b/linux-armv6-lts/Dockerfile.in
@@ -4,7 +4,7 @@ FROM ${ORG}/base:latest
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
 # Crosstool-ng version 2022-05-19
-ENV CT_VERSION crosstool-ng-1.25.0
+ENV CT_VERSION=crosstool-ng-1.25.0
 
 # This is for 32-bit ARMv6 Linux
 # Raspberry Pi is ARMv6+VFP2
@@ -19,8 +19,8 @@ RUN apt-get update \
 
 
 # The CROSS_TRIPLE is a configured alias of the "armv6-unknown-linux-gnueabihf" target.
-ENV CROSS_TRIPLE armv6-unknown-linux-gnueabihf
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV CROSS_TRIPLE=armv6-unknown-linux-gnueabihf
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -29,17 +29,17 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
-ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabihf/
+ENV PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH arm
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=arm
 
 #include "common.label-and-env"

--- a/linux-armv6-musl/Dockerfile.in
+++ b/linux-armv6-musl/Dockerfile.in
@@ -1,9 +1,9 @@
 ARG ORG=dockcross
 FROM ${ORG}/base:latest
 
-ENV XCC_PREFIX /usr/xcc
-ENV CROSS_TRIPLE armv6-linux-musleabihf
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}-cross
+ENV XCC_PREFIX=/usr/xcc
+ENV CROSS_TRIPLE=armv6-linux-musleabihf
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}-cross
 
 RUN mkdir -p ${XCC_PREFIX}
 RUN curl --max-time 15 --retry 5 -LO http://musl.cc/${CROSS_TRIPLE}-cross.tgz
@@ -18,12 +18,12 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH arm
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=arm
 
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
@@ -37,4 +37,4 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.vcs-url=$VCS_URL \
       org.label-schema.schema-version="1.0"
-ENV DEFAULT_DOCKCROSS_IMAGE ${IMAGE}:${VERSION}
+ENV DEFAULT_DOCKCROSS_IMAGE=${IMAGE}:${VERSION}

--- a/linux-armv6/Dockerfile.in
+++ b/linux-armv6/Dockerfile.in
@@ -4,7 +4,7 @@ FROM ${ORG}/base:latest
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
 # Crosstool-ng version 2022-05-19
-ENV CT_VERSION crosstool-ng-1.25.0
+ENV CT_VERSION=crosstool-ng-1.25.0
 
 # This is for 32-bit ARMv6 Linux
 # Raspberry Pi is ARMv6+VFP2
@@ -19,8 +19,8 @@ RUN apt-get update \
 
 
 # The CROSS_TRIPLE is a configured alias of the "armv6-unknown-linux-gnueabihf" target.
-ENV CROSS_TRIPLE armv6-unknown-linux-gnueabihf
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV CROSS_TRIPLE=armv6-unknown-linux-gnueabihf
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -29,17 +29,17 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
-ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabihf/
+ENV PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH arm
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=arm
 
 #include "common.label-and-env"

--- a/linux-armv7-lts/Dockerfile.in
+++ b/linux-armv7-lts/Dockerfile.in
@@ -4,7 +4,7 @@ FROM ${ORG}/base:latest
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
 # Crosstool-ng version 2022-05-19
-ENV CT_VERSION crosstool-ng-1.25.0
+ENV CT_VERSION=crosstool-ng-1.25.0
 
 # This is for 32-bit ARMv7 Linux
 #include "common.crosstool"
@@ -18,8 +18,8 @@ RUN apt-get update \
 
 
 # The CROSS_TRIPLE is a configured alias of the "armv7-unknown-linux-gnueabi" target.
-ENV CROSS_TRIPLE armv7-unknown-linux-gnueabi
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV CROSS_TRIPLE=armv7-unknown-linux-gnueabi
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -28,17 +28,17 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
-ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabihf/
+ENV PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH arm
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=arm
 
 #include "common.label-and-env"

--- a/linux-armv7/Dockerfile.in
+++ b/linux-armv7/Dockerfile.in
@@ -4,7 +4,7 @@ FROM ${ORG}/base:latest
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
 # Crosstool-ng version 2022-05-19
-ENV CT_VERSION crosstool-ng-1.25.0
+ENV CT_VERSION=crosstool-ng-1.25.0
 
 # This is for 32-bit ARMv7 Linux
 #include "common.crosstool"
@@ -18,8 +18,8 @@ RUN apt-get update \
 
 
 # The CROSS_TRIPLE is a configured alias of the "aarch64-unknown-linux-gnueabi" target.
-ENV CROSS_TRIPLE armv7-unknown-linux-gnueabi
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV CROSS_TRIPLE=armv7-unknown-linux-gnueabi
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -28,17 +28,17 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
-ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabihf/
+ENV PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH arm
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=arm
 
 #include "common.label-and-env"

--- a/linux-armv7a-lts/Dockerfile.in
+++ b/linux-armv7a-lts/Dockerfile.in
@@ -7,7 +7,7 @@ LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
 # We use a git commit while waiting for 1.25 to release (1.24 is several years old)
 # crosstool-ng 1.25.0
-ENV CT_VERSION crosstool-ng-1.25.0
+ENV CT_VERSION=crosstool-ng-1.25.0
 
 #include "common.crosstool"
 
@@ -20,9 +20,9 @@ RUN apt-get update \
 
 
 # The CROSS_TRIPLE is a configured alias of the "aarch64-unknown-linux-gnueabi" target.
-ENV CROSS_TRIPLE arm-cortexa8_neon-linux-gnueabihf
+ENV CROSS_TRIPLE=arm-cortexa8_neon-linux-gnueabihf
 
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -31,19 +31,19 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
-ENV DEFAULT_DOCKCROSS_IMAGE dockcross/linux-armv7a
+ENV DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-armv7a
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
-ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabihf/pkgconfig
+ENV PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/pkgconfig
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH arm
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=arm
 
 #include "common.label-and-env"

--- a/linux-armv7a/Dockerfile.in
+++ b/linux-armv7a/Dockerfile.in
@@ -6,7 +6,7 @@ LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 # This is for 32-bit ARMv7 Linux
 
 # Crosstool-ng version 2024-05-21
-ENV CT_VERSION crosstool-ng-1.26.0
+ENV CT_VERSION=crosstool-ng-1.26.0
 
 #include "common.crosstool"
 
@@ -19,9 +19,9 @@ RUN apt-get update \
 
 
 # The CROSS_TRIPLE is a configured alias of the "aarch64-unknown-linux-gnueabi" target.
-#ENV CROSS_TRIPLE armv7-unknown-linux-gnueabi
-ENV CROSS_TRIPLE arm-cortexa8_neon-linux-gnueabihf
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+#ENV CROSS_TRIPLE=armv7-unknown-linux-gnueabi
+ENV CROSS_TRIPLE=arm-cortexa8_neon-linux-gnueabihf
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -30,19 +30,19 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
-ENV DEFAULT_DOCKCROSS_IMAGE dockcross/linux-armv7a
+ENV DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-armv7a
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
-ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabihf/
+ENV PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH arm
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=arm
 
 #include "common.label-and-env"

--- a/linux-armv7l-musl/Dockerfile.in
+++ b/linux-armv7l-musl/Dockerfile.in
@@ -1,9 +1,9 @@
 ARG ORG=dockcross
 FROM ${ORG}/base:latest
 
-ENV XCC_PREFIX /usr/xcc
-ENV CROSS_TRIPLE armv7l-linux-musleabihf
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}-cross
+ENV XCC_PREFIX=/usr/xcc
+ENV CROSS_TRIPLE=armv7l-linux-musleabihf
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}-cross
 
 RUN mkdir -p ${XCC_PREFIX}
 RUN curl --max-time 15 --retry 5 -LO http://musl.cc/${CROSS_TRIPLE}-cross.tgz
@@ -18,12 +18,12 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH arm
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=arm
 
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
@@ -37,4 +37,4 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.vcs-url=$VCS_URL \
       org.label-schema.schema-version="1.0"
-ENV DEFAULT_DOCKCROSS_IMAGE ${IMAGE}:${VERSION}
+ENV DEFAULT_DOCKCROSS_IMAGE=${IMAGE}:${VERSION}

--- a/linux-i686/Dockerfile.in
+++ b/linux-i686/Dockerfile.in
@@ -6,7 +6,7 @@ LABEL maintainer="PJ Reid PJ.Reid@Zetier.com"
 # This is for 32-bit (i686) intel/amd devices
 
 # Crosstool-ng version 2022-05-19
-ENV CT_VERSION crosstool-ng-1.25.0
+ENV CT_VERSION=crosstool-ng-1.25.0
 
 #include "common.crosstool"
 
@@ -18,9 +18,9 @@ RUN apt-get update \
 && apt-get clean --yes
 
 # The CROSS_TRIPLE is a configured alias of the "i686-linux-gnu" target.
-ENV CROSS_TRIPLE i686-linux-gnu
+ENV CROSS_TRIPLE=i686-linux-gnu
 
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -29,15 +29,15 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH i686
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=i686
 
 #include "common.label-and-env"

--- a/linux-m68k-uclibc/Dockerfile.in
+++ b/linux-m68k-uclibc/Dockerfile.in
@@ -4,13 +4,13 @@ FROM ${ORG}/base:latest
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
 # Crosstool-ng version 2022-05-19
-ENV CT_VERSION crosstool-ng-1.25.0
+ENV CT_VERSION=crosstool-ng-1.25.0
 
 ARG QEMU_VERSION=6.0.0
 
 #include "common.crosstool"
 
-ENV CROSS_TRIPLE m68k-unknown-uclinux-uclibc
+ENV CROSS_TRIPLE=m68k-unknown-uclinux-uclibc
 
 WORKDIR /usr/src
 
@@ -22,7 +22,7 @@ RUN apt-get install -y libglib2.0-dev zlib1g-dev libpixman-1-dev && \
   make install && \
   cd .. && rm -rf qemu-${QEMU_VERSION}
 
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -31,19 +31,19 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 WORKDIR /work
 
 COPY Toolchain.cmake /usr/lib/${CROSS_TRIPLE}/
-ENV CMAKE_TOOLCHAIN_FILE /usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=/usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
 
-ENV PKG_CONFIG_PATH /usr/lib/mk68-unknown-linux-uclibc/pkgconfig
+ENV PKG_CONFIG_PATH=/usr/lib/mk68-unknown-linux-uclibc/pkgconfig
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH powerpc
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=powerpc
 
 #include "common.label-and-env"

--- a/linux-mips-lts/Dockerfile.in
+++ b/linux-mips-lts/Dockerfile.in
@@ -6,7 +6,7 @@ LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 # This is for 32-bit Big-Endian MIPS devices with hard floating point enabled
 
 # Crosstool-ng version 2022-05-19
-ENV CT_VERSION crosstool-ng-1.25.0
+ENV CT_VERSION=crosstool-ng-1.25.0
 
 #include "common.crosstool"
 
@@ -18,9 +18,9 @@ RUN apt-get update \
 && apt-get clean --yes
 
 # The CROSS_TRIPLE is a configured alias of the "mips-unknown-linux-gnu" target.
-ENV CROSS_TRIPLE mips-unknown-linux-gnu
+ENV CROSS_TRIPLE=mips-unknown-linux-gnu
 
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -29,15 +29,15 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH mips
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=mips
 
 #include "common.label-and-env"

--- a/linux-mips-uclibc/Dockerfile.in
+++ b/linux-mips-uclibc/Dockerfile.in
@@ -5,7 +5,7 @@ LABEL maintainer="Rene Helmke rene.helmke@fkie.fraunhofer.de"
 # This is for 32-bit Big-Endian MIPS devices with hard floating point enabled and uclibc.
 
 # Crosstool-ng version 2022-05-19
-ENV CT_VERSION crosstool-ng-1.25.0
+ENV CT_VERSION=crosstool-ng-1.25.0
 
 #include "common.crosstool"
 
@@ -17,9 +17,9 @@ RUN apt-get update \
 && apt-get clean --yes
 
 # The CROSS_TRIPLE is a configured alias of the "mips-unknown-linux-uclibc" target.
-ENV CROSS_TRIPLE mips-unknown-linux-uclibc
+ENV CROSS_TRIPLE=mips-unknown-linux-uclibc
 
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -28,17 +28,17 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
-ENV PKG_CONFIG_PATH /usr/lib/mips-linux-uclibc/
+ENV PKG_CONFIG_PATH=/usr/lib/mips-linux-uclibc/
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH mips
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=mips
 
 #include "common.label-and-env"

--- a/linux-mips/Dockerfile.in
+++ b/linux-mips/Dockerfile.in
@@ -6,7 +6,7 @@ LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 # This is for 32-bit Big-Endian MIPS devices with hard floating point enabled
 
 # Crosstool-ng version 2022-05-19
-ENV CT_VERSION crosstool-ng-1.25.0
+ENV CT_VERSION=crosstool-ng-1.25.0
 
 #include "common.crosstool"
 
@@ -18,9 +18,9 @@ RUN apt-get update \
 && apt-get clean --yes
 
 # The CROSS_TRIPLE is a configured alias of the "mips-unknown-linux-gnu" target.
-ENV CROSS_TRIPLE mips-unknown-linux-gnu
+ENV CROSS_TRIPLE=mips-unknown-linux-gnu
 
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -29,15 +29,15 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH mips
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=mips
 
 #include "common.label-and-env"

--- a/linux-mipsel-lts/Dockerfile.in
+++ b/linux-mipsel-lts/Dockerfile.in
@@ -4,7 +4,7 @@ FROM ${ORG}/base:latest
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
 # Crosstool-ng version 2022-05-19
-ENV CT_VERSION crosstool-ng-1.25.0
+ENV CT_VERSION=crosstool-ng-1.25.0
 
 # This is for 32-bit or 64-bit mipsel Linux (multilib)
 #include "common.crosstool"
@@ -18,8 +18,8 @@ RUN apt-get update \
 
 
 # The CROSS_TRIPLE is a configured alias of the "mipsel-unknown-linux-gnu" target.
-ENV CROSS_TRIPLE mipsel-unknown-linux-gnu
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV CROSS_TRIPLE=mipsel-unknown-linux-gnu
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -28,17 +28,17 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
-ENV PKG_CONFIG_PATH /usr/lib/mipsel-unknown-linux-gnu/
+ENV PKG_CONFIG_PATH=/usr/lib/mipsel-unknown-linux-gnu/
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH mipsel
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=mipsel
 
 #include "common.label-and-env"

--- a/linux-ppc/Dockerfile.in
+++ b/linux-ppc/Dockerfile.in
@@ -4,13 +4,13 @@ FROM ${ORG}/base:latest
 LABEL maintainer="Matt McCormick matt@mmmccormick.com and Fancy2209"
 
 # Crosstool-ng version 2024-08-04
-ENV CT_VERSION crosstool-ng-1.26.0
+ENV CT_VERSION=crosstool-ng-1.26.0
 
 ARG QEMU_VERSION=6.0.0
 
 #include "common.crosstool"
 
-ENV CROSS_TRIPLE powerpc-unknown-linux-gnu
+ENV CROSS_TRIPLE=powerpc-unknown-linux-gnu
 
 WORKDIR /usr/src
 
@@ -22,7 +22,7 @@ RUN apt-get install -y libglib2.0-dev zlib1g-dev libpixman-1-dev && \
   make install && \
   cd .. && rm -rf qemu-${QEMU_VERSION}
 
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -31,19 +31,19 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 WORKDIR /work
 
 COPY Toolchain.cmake /usr/lib/${CROSS_TRIPLE}/
-ENV CMAKE_TOOLCHAIN_FILE /usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=/usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
 
-ENV PKG_CONFIG_PATH /usr/lib/powerpc-unknown-linux-gnu/pkgconfig
+ENV PKG_CONFIG_PATH=/usr/lib/powerpc-unknown-linux-gnu/pkgconfig
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH powerpc
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=powerpc
 
 #include "common.label-and-env"

--- a/linux-ppc64le-lts/Dockerfile.in
+++ b/linux-ppc64le-lts/Dockerfile.in
@@ -4,13 +4,13 @@ FROM ${ORG}/base:latest
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
 # Crosstool-ng version 2023-09-21
-ENV CT_VERSION crosstool-ng-1.25.0
+ENV CT_VERSION=crosstool-ng-1.25.0
 
 ARG QEMU_VERSION=6.0.0
 
 #include "common.crosstool"
 
-ENV CROSS_TRIPLE powerpc64le-unknown-linux-gnu
+ENV CROSS_TRIPLE=powerpc64le-unknown-linux-gnu
 
 WORKDIR /usr/src
 
@@ -22,7 +22,7 @@ RUN apt-get install -y libglib2.0-dev zlib1g-dev libpixman-1-dev && \
   make install && \
   cd .. && rm -rf qemu-${QEMU_VERSION}
 
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -31,19 +31,19 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 WORKDIR /work
 
 COPY Toolchain.cmake /usr/lib/${CROSS_TRIPLE}/
-ENV CMAKE_TOOLCHAIN_FILE /usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=/usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
 
-ENV PKG_CONFIG_PATH /usr/lib/powerpc64le-unknown-linux-gnu/pkgconfig
+ENV PKG_CONFIG_PATH=/usr/lib/powerpc64le-unknown-linux-gnu/pkgconfig
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH powerpc
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=powerpc
 
 #include "common.label-and-env"

--- a/linux-ppc64le/Dockerfile.in
+++ b/linux-ppc64le/Dockerfile.in
@@ -4,13 +4,13 @@ FROM ${ORG}/base:latest
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
 # Crosstool-ng version 2024-08-04
-ENV CT_VERSION crosstool-ng-1.26.0
+ENV CT_VERSION=crosstool-ng-1.26.0
 
 ARG QEMU_VERSION=6.0.0
 
 #include "common.crosstool"
 
-ENV CROSS_TRIPLE powerpc64le-unknown-linux-gnu
+ENV CROSS_TRIPLE=powerpc64le-unknown-linux-gnu
 
 WORKDIR /usr/src
 
@@ -22,7 +22,7 @@ RUN apt-get install -y libglib2.0-dev zlib1g-dev libpixman-1-dev && \
   make install && \
   cd .. && rm -rf qemu-${QEMU_VERSION}
 
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -31,19 +31,19 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 WORKDIR /work
 
 COPY Toolchain.cmake /usr/lib/${CROSS_TRIPLE}/
-ENV CMAKE_TOOLCHAIN_FILE /usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=/usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
 
-ENV PKG_CONFIG_PATH /usr/lib/powerpc64le-unknown-linux-gnu/pkgconfig
+ENV PKG_CONFIG_PATH=/usr/lib/powerpc64le-unknown-linux-gnu/pkgconfig
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH powerpc
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=powerpc
 
 #include "common.label-and-env"

--- a/linux-riscv32/Dockerfile.in
+++ b/linux-riscv32/Dockerfile.in
@@ -4,13 +4,13 @@ FROM ${ORG}/base:latest
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
 # Crosstool-ng version 2022-05-19
-ENV CT_VERSION crosstool-ng-1.25.0
+ENV CT_VERSION=crosstool-ng-1.25.0
 
 ARG QEMU_VERSION=6.0.0
 
 #include "common.crosstool"
 
-ENV CROSS_TRIPLE riscv32-unknown-linux-gnu
+ENV CROSS_TRIPLE=riscv32-unknown-linux-gnu
 
 WORKDIR /usr/src
 
@@ -22,7 +22,7 @@ RUN apt-get install -y libglib2.0-dev zlib1g-dev libpixman-1-dev && \
   make install && \
   cd .. && rm -rf qemu-${QEMU_VERSION}
 
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -31,19 +31,19 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 WORKDIR /work
 
 COPY Toolchain.cmake /usr/lib/${CROSS_TRIPLE}/
-ENV CMAKE_TOOLCHAIN_FILE /usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=/usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
 
-ENV PKG_CONFIG_PATH /usr/lib/riscv32-unknown-linux-gnu/pkgconfig
+ENV PKG_CONFIG_PATH=/usr/lib/riscv32-unknown-linux-gnu/pkgconfig
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH riscv32
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=riscv32
 
 #include "common.label-and-env"

--- a/linux-riscv64/Dockerfile.in
+++ b/linux-riscv64/Dockerfile.in
@@ -4,13 +4,13 @@ FROM ${ORG}/base:latest
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
 # Crosstool-ng version 2022-05-19
-ENV CT_VERSION crosstool-ng-1.25.0
+ENV CT_VERSION=crosstool-ng-1.25.0
 
 ARG QEMU_VERSION=6.0.0
 
 #include "common.crosstool"
 
-ENV CROSS_TRIPLE riscv64-unknown-linux-gnu
+ENV CROSS_TRIPLE=riscv64-unknown-linux-gnu
 
 WORKDIR /usr/src
 
@@ -22,7 +22,7 @@ RUN apt-get install -y libglib2.0-dev zlib1g-dev libpixman-1-dev && \
   make install && \
   cd .. && rm -rf qemu-${QEMU_VERSION}
 
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -31,19 +31,19 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 WORKDIR /work
 
 COPY Toolchain.cmake /usr/lib/${CROSS_TRIPLE}/
-ENV CMAKE_TOOLCHAIN_FILE /usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=/usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
 
-ENV PKG_CONFIG_PATH /usr/lib/riscv64-unknown-linux-gnu/pkgconfig
+ENV PKG_CONFIG_PATH=/usr/lib/riscv64-unknown-linux-gnu/pkgconfig
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH riscv64
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=riscv64
 
 #include "common.label-and-env"

--- a/linux-s390x/Dockerfile.in
+++ b/linux-s390x/Dockerfile.in
@@ -6,7 +6,7 @@ LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 # This is for 64-bit S390X Linux machine
 
 # Crosstool-ng version 2022-05-19
-ENV CT_VERSION crosstool-ng-1.25.0
+ENV CT_VERSION=crosstool-ng-1.25.0
 
 #include "common.crosstool"
 
@@ -18,9 +18,9 @@ RUN apt-get update \
 && apt-get clean --yes
 
 # The CROSS_TRIPLE is a configured alias of the "s390x-ibm-linux-gnu" target.
-ENV CROSS_TRIPLE s390x-ibm-linux-gnu
+ENV CROSS_TRIPLE=s390x-ibm-linux-gnu
 
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -29,15 +29,15 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH s390
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=s390
 
 #include "common.label-and-env"

--- a/linux-x64-clang/Dockerfile.in
+++ b/linux-x64-clang/Dockerfile.in
@@ -27,8 +27,8 @@ RUN echo "deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm main" >> /et
     && c++ --version \
     && cpp --version
 
-ENV CROSS_TRIPLE x86_64-linux-gnu
-ENV CROSS_ROOT /usr/bin
+ENV CROSS_TRIPLE=x86_64-linux-gnu
+ENV CROSS_ROOT=/usr/bin
 ENV CC=/usr/bin/clang-${CLANG_VERSION}  \
     CPP=/usr/bin/clang-cpp-${CLANG_VERSION} \
     CXX=/usr/bin/clang++-${CLANG_VERSION} \
@@ -40,6 +40,6 @@ ENV CC=/usr/bin/clang-${CLANG_VERSION}  \
 COPY ${CROSS_TRIPLE}-noop.sh /usr/bin/${CROSS_TRIPLE}-noop
 
 COPY Toolchain.cmake /usr/lib/${CROSS_TRIPLE}/
-ENV CMAKE_TOOLCHAIN_FILE /usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=/usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
 
 #include "common.label-and-env"

--- a/linux-x64-tinycc/Dockerfile.in
+++ b/linux-x64-tinycc/Dockerfile.in
@@ -26,8 +26,8 @@ ENV PATH="/usr/local/bin:${PATH}"
 # Test if compiler work
 RUN tcc -v
 
-ENV CROSS_TRIPLE x86_64-linux-gnu
-ENV CROSS_ROOT /usr/bin
+ENV CROSS_TRIPLE=x86_64-linux-gnu
+ENV CROSS_ROOT=/usr/bin
 ENV AS=/usr/bin/${CROSS_TRIPLE}-as \
     AR=/usr/bin/${CROSS_TRIPLE}-ar \
     CC=/usr/local/bin/tcc \
@@ -39,6 +39,6 @@ ENV AS=/usr/bin/${CROSS_TRIPLE}-as \
 COPY ${CROSS_TRIPLE}-noop.sh /usr/bin/${CROSS_TRIPLE}-noop
 
 COPY Toolchain.cmake /usr/lib/${CROSS_TRIPLE}/
-ENV CMAKE_TOOLCHAIN_FILE /usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=/usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
 
 #include "common.label-and-env"

--- a/linux-x64/Dockerfile.in
+++ b/linux-x64/Dockerfile.in
@@ -10,8 +10,8 @@ RUN apt-get update && \
     libtbb-dev \
     && apt-get clean --yes
 
-ENV CROSS_TRIPLE x86_64-linux-gnu
-ENV CROSS_ROOT /usr/bin
+ENV CROSS_TRIPLE=x86_64-linux-gnu
+ENV CROSS_ROOT=/usr/bin
 ENV AS=/usr/bin/${CROSS_TRIPLE}-as \
     AR=/usr/bin/${CROSS_TRIPLE}-ar \
     CC=/usr/bin/${CROSS_TRIPLE}-gcc \
@@ -23,6 +23,6 @@ ENV AS=/usr/bin/${CROSS_TRIPLE}-as \
 COPY ${CROSS_TRIPLE}-noop.sh /usr/bin/${CROSS_TRIPLE}-noop
 
 COPY Toolchain.cmake /usr/lib/${CROSS_TRIPLE}/
-ENV CMAKE_TOOLCHAIN_FILE /usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=/usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
 
 #include "common.label-and-env"

--- a/linux-x86/Dockerfile.in
+++ b/linux-x86/Dockerfile.in
@@ -14,9 +14,9 @@ RUN dpkg --add-architecture i386 && \
     libexpat1-dev:i386 \
     ncurses-dev:i386
 
-ENV CROSS_TRIPLE i686-linux-gnu
-ENV CROSS_ROOT /usr/${CROSS_TRIPLE}
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_TRIPLE=i686-linux-gnu
+ENV CROSS_ROOT=/usr/${CROSS_TRIPLE}
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
 RUN mkdir -p ${CROSS_ROOT}/bin
 COPY ${CROSS_TRIPLE}.sh ${CROSS_ROOT}/bin/${CROSS_TRIPLE}.sh
 COPY ${CROSS_TRIPLE}-as.sh ${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as.sh
@@ -76,11 +76,11 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld
 
 COPY Toolchain.cmake /usr/lib/${CROSS_TRIPLE}/
-ENV CMAKE_TOOLCHAIN_FILE /usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=/usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
 
 # Linux kernel cross compilation variables
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH x86
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=x86
 
 COPY linux32-entrypoint.sh /dockcross/
 ENTRYPOINT ["/dockcross/linux32-entrypoint.sh"]

--- a/linux-x86_64-full/Dockerfile.in
+++ b/linux-x86_64-full/Dockerfile.in
@@ -7,7 +7,7 @@ LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
 # Buildroot version
 # buildroot master 2021-09-21
-ENV BR_VERSION 279167ee8dc37b1c41ff9076d6769c950d5a33f1
+ENV BR_VERSION=279167ee8dc37b1c41ff9076d6769c950d5a33f1
 
 #include "common.buildroot"
 
@@ -19,8 +19,8 @@ RUN apt-get update \
 && apt-get clean --yes
 
 # The CROSS_TRIPLE is a configured alias of the "x86_64-buildroot-linux-gnu" target.
-ENV CROSS_TRIPLE x86_64-buildroot-linux-gnu
-ENV CROSS_ROOT /buildroot
+ENV CROSS_TRIPLE=x86_64-buildroot-linux-gnu
+ENV CROSS_ROOT=/buildroot
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -29,17 +29,17 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
-#ENV PKG_CONFIG_PATH /usr/lib/x86_64-linux-gnu/pkgconfig
+#ENV PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH arm64
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=arm64
 
 #include "common.label-and-env"

--- a/linux-xtensa-uclibc/Dockerfile.in
+++ b/linux-xtensa-uclibc/Dockerfile.in
@@ -4,13 +4,13 @@ FROM ${ORG}/base:latest
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
 # Crosstool-ng version 2022-05-19
-ENV CT_VERSION crosstool-ng-1.25.0
+ENV CT_VERSION=crosstool-ng-1.25.0
 
-ENV QEMU_VERSION 6.0.0
+ENV QEMU_VERSION=6.0.0
 
 #include "common.crosstool"
 
-ENV CROSS_TRIPLE xtensa-fsf-linux-uclibc
+ENV CROSS_TRIPLE=xtensa-fsf-linux-uclibc
 
 WORKDIR /usr/src
 
@@ -22,7 +22,7 @@ RUN apt-get install -y libglib2.0-dev zlib1g-dev libpixman-1-dev && \
   make install && \
   cd .. && rm -rf qemu-${QEMU_VERSION}
 
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
@@ -31,19 +31,19 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 WORKDIR /work
 
 COPY Toolchain.cmake /usr/lib/${CROSS_TRIPLE}/
-ENV CMAKE_TOOLCHAIN_FILE /usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=/usr/lib/${CROSS_TRIPLE}/Toolchain.cmake
 
-ENV PKG_CONFIG_PATH /usr/lib/xtensa-fsf-linux-uclibc/pkgconfig
+ENV PKG_CONFIG_PATH=/usr/lib/xtensa-fsf-linux-uclibc/pkgconfig
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH xtensa
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=xtensa
 
 #include "common.label-and-env"

--- a/manylinux2014-aarch64/Dockerfile.in
+++ b/manylinux2014-aarch64/Dockerfile.in
@@ -10,7 +10,7 @@ LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 # This is for 64-bit ARM Manylinux machine
 
 # Crosstool-ng version
-ENV CT_VERSION crosstool-ng-1.25.0
+ENV CT_VERSION=crosstool-ng-1.25.0
 
 #include "common-manylinux.crosstool"
 
@@ -23,9 +23,9 @@ RUN \
   yum clean all
 
 # The CROSS_TRIPLE is a configured alias of the "aarch64-unknown-linux-gnu" target.
-ENV CROSS_TRIPLE aarch64-unknown-linux-gnu
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_TRIPLE=aarch64-unknown-linux-gnu
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
 
 # Running scripts to cross compile python and copy libstdc++ into toolcain
 ADD manylinux2014-aarch64/xc_script /tmp/
@@ -44,19 +44,19 @@ ENV AS=${CROSS_TRIPLE}-as \
     STRIP=${CROSS_TRIPLE}-strip \
     OBJCOPY=${CROSS_TRIPLE}-objcopy
 
-ENV QEMU_LD_PREFIX "${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
-ENV QEMU_SET_ENV "LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
+ENV QEMU_LD_PREFIX="${CROSS_ROOT}/${CROSS_TRIPLE}/sysroot"
+ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 COPY manylinux2014-aarch64/Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
-ENV PKG_CONFIG_PATH /usr/lib/aarch64-linux-gnu/pkgconfig
+ENV PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
 
 # Linux kernel cross compilation variables
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH arm64
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=arm64
 
-ENV AUDITWHEEL_ARCH aarch64
-ENV AUDITWHEEL_PLAT manylinux2014_$AUDITWHEEL_ARCH
+ENV AUDITWHEEL_ARCH=aarch64
+ENV AUDITWHEEL_PLAT=manylinux2014_$AUDITWHEEL_ARCH
 
 #include "common.label-and-env"

--- a/manylinux2014-x64/Dockerfile.in
+++ b/manylinux2014-x64/Dockerfile.in
@@ -3,7 +3,7 @@ FROM quay.io/pypa/manylinux2014_x86_64:2024-07-20-e0def9a
 
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
-ENV DEFAULT_DOCKCROSS_IMAGE dockcross/manylinux2014-x64
+ENV DEFAULT_DOCKCROSS_IMAGE=dockcross/manylinux2014-x64
 
 #include "common.manylinux2014"
 
@@ -16,8 +16,8 @@ ENV DEFAULT_DOCKCROSS_IMAGE dockcross/manylinux2014-x64
 RUN echo $'#!/bin/bash\n\
 LD_PRELOAD=/usr/lib64/libcurl.so.4 /usr/bin/yum "$@"' > /usr/local/bin/yum && chmod a+x /usr/local/bin/yum
 
-ENV CROSS_TRIPLE x86_64-linux-gnu
-ENV CROSS_ROOT /opt/rh/devtoolset-10/root/usr/bin
+ENV CROSS_TRIPLE=x86_64-linux-gnu
+ENV CROSS_ROOT=/opt/rh/devtoolset-10/root/usr/bin
 ENV AS=${CROSS_ROOT}/as \
     AR=${CROSS_ROOT}/ar \
     CC=${CROSS_ROOT}/gcc \
@@ -29,6 +29,6 @@ ENV AS=${CROSS_ROOT}/as \
 COPY linux-x64/${CROSS_TRIPLE}-noop.sh /usr/bin/${CROSS_TRIPLE}-noop
 
 COPY manylinux2014-x64/Toolchain.cmake ${CROSS_ROOT}/../lib/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/../lib/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/../lib/Toolchain.cmake
 
 #include "common.label-and-env"

--- a/manylinux2014-x86/Dockerfile.in
+++ b/manylinux2014-x86/Dockerfile.in
@@ -3,7 +3,7 @@ FROM quay.io/pypa/manylinux2014_i686:2024-07-20-e0def9a
 
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
-ENV DEFAULT_DOCKCROSS_IMAGE dockcross/manylinux2014-x86
+ENV DEFAULT_DOCKCROSS_IMAGE=dockcross/manylinux2014-x86
 
 #include "common.manylinux2014"
 
@@ -16,8 +16,8 @@ ENV DEFAULT_DOCKCROSS_IMAGE dockcross/manylinux2014-x86
 RUN echo $'#!/bin/bash\n\
 LD_PRELOAD=/usr/lib/libcurl.so.4 /usr/bin/yum "$@"' > /usr/local/bin/yum && chmod a+x /usr/local/bin/yum
 
-ENV CROSS_TRIPLE i686-linux-gnu
-ENV CROSS_ROOT /opt/rh/devtoolset-10/root/usr/bin
+ENV CROSS_TRIPLE=i686-linux-gnu
+ENV CROSS_ROOT=/opt/rh/devtoolset-10/root/usr/bin
 ENV AS=${CROSS_ROOT}/as \
     AR=${CROSS_ROOT}/ar \
     CC=${CROSS_ROOT}/gcc \
@@ -29,7 +29,7 @@ ENV AS=${CROSS_ROOT}/as \
 COPY linux-x86/${CROSS_TRIPLE}-noop.sh /usr/bin/${CROSS_TRIPLE}-noop
 
 COPY manylinux2014-x86/Toolchain.cmake ${CROSS_ROOT}/../lib/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/../lib/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/../lib/Toolchain.cmake
 
 COPY linux-x86/linux32-entrypoint.sh /dockcross/
 ENTRYPOINT ["/dockcross/linux32-entrypoint.sh"]
@@ -46,4 +46,4 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.vcs-url=$VCS_URL \
       org.label-schema.schema-version="1.0"
-ENV DEFAULT_DOCKCROSS_IMAGE ${IMAGE}:${VERSION}
+ENV DEFAULT_DOCKCROSS_IMAGE=${IMAGE}:${VERSION}

--- a/manylinux_2_28-x64/Dockerfile.in
+++ b/manylinux_2_28-x64/Dockerfile.in
@@ -3,7 +3,7 @@ FROM quay.io/pypa/manylinux_2_28_x86_64:2024-07-20-e0def9a
 
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
-ENV DEFAULT_DOCKCROSS_IMAGE dockcross/manylinux_2_28-x64
+ENV DEFAULT_DOCKCROSS_IMAGE=dockcross/manylinux_2_28-x64
 
 #include "common.manylinux_2_28"
 
@@ -11,8 +11,8 @@ ENV DEFAULT_DOCKCROSS_IMAGE dockcross/manylinux_2_28-x64
 
 #include "common.docker"
 
-ENV CROSS_TRIPLE x86_64-linux-gnu
-ENV CROSS_ROOT /opt/rh/gcc-toolset-12/root/bin/
+ENV CROSS_TRIPLE=x86_64-linux-gnu
+ENV CROSS_ROOT=/opt/rh/gcc-toolset-12/root/bin/
 ENV AS=${CROSS_ROOT}/as \
     AR=${CROSS_ROOT}/ar \
     CC=${CROSS_ROOT}/gcc \
@@ -24,6 +24,6 @@ ENV AS=${CROSS_ROOT}/as \
 COPY linux-x64/${CROSS_TRIPLE}-noop.sh /usr/bin/${CROSS_TRIPLE}-noop
 
 COPY manylinux_2_28-x64/Toolchain.cmake ${CROSS_ROOT}/../lib/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/../lib/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/../lib/Toolchain.cmake
 
 #include "common.label-and-env"

--- a/windows-arm64/Dockerfile.in
+++ b/windows-arm64/Dockerfile.in
@@ -3,9 +3,9 @@ FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
-ENV XCC_PREFIX /usr/xcc
-ENV CROSS_TRIPLE aarch64-w64-mingw32
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}-cross
+ENV XCC_PREFIX=/usr/xcc
+ENV CROSS_TRIPLE=aarch64-w64-mingw32
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}-cross
 
 ARG DOWNLOAD_URL=https://github.com/mstorsjo/llvm-mingw/releases/download/20220323/llvm-mingw-20220323-msvcrt-ubuntu-18.04-x86_64.tar.xz
 ENV DOWNLOAD_URL=${DOWNLOAD_URL}
@@ -20,11 +20,11 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH arm64
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=arm64
 
 #include "common.label-and-env"

--- a/windows-armv7/Dockerfile.in
+++ b/windows-armv7/Dockerfile.in
@@ -3,9 +3,9 @@ FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
-ENV XCC_PREFIX /usr/xcc
-ENV CROSS_TRIPLE armv7-w64-mingw32
-ENV CROSS_ROOT ${XCC_PREFIX}/${CROSS_TRIPLE}-cross
+ENV XCC_PREFIX=/usr/xcc
+ENV CROSS_TRIPLE=armv7-w64-mingw32
+ENV CROSS_ROOT=${XCC_PREFIX}/${CROSS_TRIPLE}-cross
 
 ARG DOWNLOAD_URL=https://github.com/mstorsjo/llvm-mingw/releases/download/20220323/llvm-mingw-20220323-msvcrt-ubuntu-18.04-x86_64.tar.xz
 ENV DOWNLOAD_URL=${DOWNLOAD_URL}
@@ -20,11 +20,11 @@ ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
 COPY Toolchain.cmake ${CROSS_ROOT}/
-ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
+ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
 
 # Linux kernel cross compilation variables
-ENV PATH ${PATH}:${CROSS_ROOT}/bin
-ENV CROSS_COMPILE ${CROSS_TRIPLE}-
-ENV ARCH arm
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
+ENV CROSS_COMPILE=${CROSS_TRIPLE}-
+ENV ARCH=arm
 
 #include "common.label-and-env"

--- a/windows-shared-x64-posix/Dockerfile.in
+++ b/windows-shared-x64-posix/Dockerfile.in
@@ -3,7 +3,7 @@ FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
-ENV WINEARCH win64
+ENV WINEARCH=win64
 ARG MXE_TARGET_ARCH=x86_64
 ARG MXE_TARGET_THREAD=.posix
 ARG MXE_TARGET_LINK=shared

--- a/windows-shared-x64/Dockerfile.in
+++ b/windows-shared-x64/Dockerfile.in
@@ -3,7 +3,7 @@ FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
-ENV WINEARCH win64
+ENV WINEARCH=win64
 ARG MXE_TARGET_ARCH=x86_64
 ARG MXE_TARGET_THREAD=
 ARG MXE_TARGET_LINK=shared

--- a/windows-shared-x86/Dockerfile.in
+++ b/windows-shared-x86/Dockerfile.in
@@ -3,7 +3,7 @@ FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
-ENV WINEARCH win32
+ENV WINEARCH=win32
 ARG MXE_TARGET_ARCH=i686
 ARG MXE_TARGET_THREAD=
 ARG MXE_TARGET_LINK=shared

--- a/windows-static-x64-posix/Dockerfile.in
+++ b/windows-static-x64-posix/Dockerfile.in
@@ -3,7 +3,7 @@ FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
-ENV WINEARCH win64
+ENV WINEARCH=win64
 ARG MXE_TARGET_ARCH=x86_64
 ARG MXE_TARGET_THREAD=.posix
 ARG MXE_TARGET_LINK=static

--- a/windows-static-x64/Dockerfile.in
+++ b/windows-static-x64/Dockerfile.in
@@ -3,7 +3,7 @@ FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
-ENV WINEARCH win64
+ENV WINEARCH=win64
 ARG MXE_TARGET_ARCH=x86_64
 ARG MXE_TARGET_THREAD=
 ARG MXE_TARGET_LINK=static

--- a/windows-static-x86/Dockerfile.in
+++ b/windows-static-x86/Dockerfile.in
@@ -3,7 +3,7 @@ FROM ${ORG}/base:latest
 
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 
-ENV WINEARCH win32
+ENV WINEARCH=win32
 ARG MXE_TARGET_ARCH=i686
 ARG MXE_TARGET_THREAD=
 ARG MXE_TARGET_LINK=static


### PR DESCRIPTION
     - LegacyKeyValueFormat: "ENV key=value" should be used
         instead of legacy "ENV key value" format (line 42)
    
    """
    The new format for declaring environment variables in Dockerfiles is ENV
    key=value. This format, where the key and value are separated by an
    equals sign (=), is the recommended approach. The older format, ENV key
    value (with a space as a separator), is deprecated.
    """ -- google search