### PR TITLE
ci: use versioned build image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   base:
     name: base
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout code
         uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
   image:
     name: ${{ matrix.arch_name.image }}
     needs: base
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       OCI_EXE: docker
     strategy:


### PR DESCRIPTION
Make CI more reproducible and prevent non-explicit changes from breaking
builds.
