### PR TITLE
Install rustup globally and add Rust support to Android images

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Cross compiling toolchains in Docker images.
 - [Meson](https://mesonbuild.com) is pre-installed.
 - [Conan.io](https://www.conan.io) can be used as a package manager.
 - Toolchain files configured for CMake.
+- [Rustup](https://rustup.rs/) is pre-installed.
+- Some images (e.g. android) are configured for Rust.
 - Current directory is mounted as the container\'s workdir, `/work`.
 - Works with the [Docker for Mac](https://docs.docker.com/docker-for-mac/) and [Docker for Windows](https://docs.docker.com/docker-for-windows/).
 - Support using alternative container executor by setting **OCI_EXE** environment variable. By default, it searches for [docker](https://www.docker.com) and [podman](https://podman.io) executable.
@@ -30,6 +32,7 @@ Cross compiling toolchains in Docker images.
 3. `dockcross ninja -Cbuild`: Run ninja in the `./build` directory.
 4. `dockcross bash -c '$CC test/C/hello.c -o hello'`: Build the *hello.c* file with the compiler identified with the `CC` environmental variable in the build environment.
 5. `dockcross bash`: Run an interactive shell in the build environment.
+6. `dockcross cargo build`: Build the current Rust project.
 
 Note that commands are executed verbatim. If any shell processing for environment variable expansion or redirection is required, please use
 

--- a/android-arm/Dockerfile.in
+++ b/android-arm/Dockerfile.in
@@ -35,6 +35,12 @@ RUN mkdir -p /build && \
     find ${CROSS_ROOT} -exec chmod a+r '{}' \; && \
     find ${CROSS_ROOT} -executable -exec chmod a+x '{}' \;
 
+# Prepare Rust
+ENV PATH="/root/.cargo/bin/:$PATH"
+RUN rustup target add armv7-linux-androideabi
+COPY config.toml /root/.cargo/
+
+# Prepare CMake
 COPY Toolchain.cmake ${CROSS_ROOT}/
 ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
 

--- a/android-arm/config.toml
+++ b/android-arm/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "armv7-linux-androideabi"
+
+[target.armv7-linux-androideabi]
+linker = "/usr/arm-linux-androideabi/bin/armv7a-linux-androideabi23-clang"

--- a/android-arm64/Dockerfile.in
+++ b/android-arm64/Dockerfile.in
@@ -39,7 +39,12 @@ RUN mkdir -p /build && \
     find ${CROSS_ROOT} -exec chmod a+r '{}' \; && \
     find ${CROSS_ROOT} -executable -exec chmod a+x '{}' \;
 
+# Prepare Rust
+ENV PATH="/root/.cargo/bin/:$PATH"
+RUN rustup target add aarch64-linux-android
+COPY config.toml /root/.cargo/
 
+# Prepare CMake
 COPY Toolchain.cmake ${CROSS_ROOT}/
 ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
 

--- a/android-arm64/config.toml
+++ b/android-arm64/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "aarch64-linux-android"
+
+[target.aarch64-linux-android]
+linker = "/usr/aarch64-linux-android/bin/aarch64-linux-android-clang"

--- a/android-x86/Dockerfile
+++ b/android-x86/Dockerfile
@@ -29,6 +29,12 @@ RUN mkdir -p /build && \
     find ${CROSS_ROOT} -exec chmod a+r '{}' \; && \
     find ${CROSS_ROOT} -executable -exec chmod a+x '{}' \;
 
+# Prepare Rust
+ENV PATH="/root/.cargo/bin/:$PATH"
+RUN rustup target add i686-linux-android
+COPY config.toml /root/.cargo/
+
+# Prepare CMake
 COPY Toolchain.cmake ${CROSS_ROOT}/
 ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
 

--- a/android-x86/config.toml
+++ b/android-x86/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "i686-linux-android"
+
+[target.i686-linux-android]
+linker = "/usr/i686-linux-android/bin/i686-linux-android23-clang"

--- a/android-x86_64/Dockerfile
+++ b/android-x86_64/Dockerfile
@@ -29,6 +29,12 @@ RUN mkdir -p /build && \
     find ${CROSS_ROOT} -exec chmod a+r '{}' \; && \
     find ${CROSS_ROOT} -executable -exec chmod a+x '{}' \;
 
+# Prepare Rust
+ENV PATH="/root/.cargo/bin/:$PATH"
+RUN rustup target add x86_64-linux-android
+COPY config.toml /root/.cargo/
+
+# Prepare CMake
 COPY Toolchain.cmake ${CROSS_ROOT}/
 ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/Toolchain.cmake
 

--- a/android-x86_64/config.toml
+++ b/android-x86_64/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "x86_64-linux-android"
+
+[target.x86_64-linux-android]
+linker = "/usr/x86_64-linux-android/bin/x86_64-linux-android-clang"

--- a/common/common.docker
+++ b/common/common.docker
@@ -25,6 +25,7 @@ COPY \
   imagefiles/build-and-install-ninja.sh \
   imagefiles/build-and-install-openssl.sh \
   imagefiles/build-and-install-openssh.sh \
+  imagefiles/build-and-install-rustup.sh \
   imagefiles/install-cmake-binary.sh \
   imagefiles/install-liquidprompt-binary.sh \
   imagefiles/install-python-packages.sh \
@@ -38,6 +39,7 @@ RUN \
   /buildscripts/build-and-install-curl.sh && \
   /buildscripts/build-and-install-git.sh && \
   /buildscripts/build-and-install-cmake.sh $X86_FLAG && \
+  /buildscripts/build-and-install-rustup.sh && \
   /buildscripts/install-liquidprompt-binary.sh && \
   PYTHON=$([ -e /opt/python/cp38-cp38/bin/python ] && echo "/opt/python/cp38-cp38/bin/python" || echo "python3") && \
   /buildscripts/install-python-packages.sh -python ${PYTHON} && \

--- a/imagefiles/build-and-install-rustup.sh
+++ b/imagefiles/build-and-install-rustup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -ex
+
+if ! command -v curl &> /dev/null; then
+	echo >&2 'error: "curl" not found!'
+	exit 1
+fi
+
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y


### PR DESCRIPTION
I have been using it with android-arm64 and it works for me :tada:.

I haven't tested the other images on a real device, but they seem to build my project fine, as shown in the output of `file`:

```
% file target/aarch64-linux-android/debug/libmyproject.so
target/aarch64-linux-android/debug/libmyproject.so: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, for Android 23, built by NDK r25b (8937393), with debug_info, not stripped

% file target/armv7-linux-androideabi/debug/libmyproject.so
target/armv7-linux-androideabi/debug/libmyproject.so: ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV), dynamically linked, for Android 23, built by NDK r25b (8937393), with debug_info, not stripped

% file target/i686-linux-android/debug/libmyproject.so
target/i686-linux-android/debug/libmyproject.so: ELF 32-bit LSB shared object, Intel i386, version 1 (SYSV), dynamically linked, for Android 23, built by NDK r25b (8937393), with debug_info, not stripped

% file target/x86_64-linux-android/debug/libmyproject.so
target/x86_64-linux-android/debug/libmyproject.so: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, for Android 23, built by NDK r25b (8937393), with debug_info, not stripped
```

What do you think?