### PR TITLE
Add CROSS_ROOT env variable on windows

### DIFF
--- a/common/common.windows
+++ b/common/common.windows
@@ -125,14 +125,15 @@ RUN \
   #
   rm -rf /tmp/wine-*
 
-ENV PATH=${PATH}:/usr/src/mxe/usr/bin
+ENV CROSS_ROOT=/usr/src/mxe/usr
+ENV PATH=${PATH}:${CROSS_ROOT}/bin
 ENV CROSS_TRIPLE=${MXE_TARGET_ARCH}-w64-mingw32.${MXE_TARGET_LINK}${MXE_TARGET_THREAD}
-ENV AS=/usr/src/mxe/usr/bin/${CROSS_TRIPLE}-as \
-    AR=/usr/src/mxe/usr/bin/${CROSS_TRIPLE}-ar \
-    CC=/usr/src/mxe/usr/bin/${CROSS_TRIPLE}-gcc \
-    CPP=/usr/src/mxe/usr/bin/${CROSS_TRIPLE}-cpp \
-    CXX=/usr/src/mxe/usr/bin/${CROSS_TRIPLE}-g++ \
-    LD=/usr/src/mxe/usr/bin/${CROSS_TRIPLE}-ld \
-    FC=/usr/src/mxe/usr/bin/${CROSS_TRIPLE}-gfortran
+ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
+    AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
+    CC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gcc \
+    CPP=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-cpp \
+    CXX=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-g++ \
+    LD=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ld \
+    FC=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-gfortran
 
 WORKDIR /work


### PR DESCRIPTION
The cross root variable is useful when there is need to install additional libs in a child dockerfile, so ensure it is set in the windows variants.