### PR TITLE
Makefile: address HOST_ARCH specification syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ TAG_FLAG := $(or $(TAG_FLAG), --tag)
 ORG = dockcross
 
 # Host architecture
-HOST_ARCH := $(or $(HOST_ARCH), shell uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')
+HOST_ARCH := $(or $(HOST_ARCH), $(shell uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/'))
 
 # Directory where to generate the dockcross script for each images (e.g bin/dockcross-manylinux2014-x64)
 BIN = ./bin


### PR DESCRIPTION
For:

```
Makefile:297: target '-e' given more than once in the same rule
35
Makefile:305: warning: overriding recipe for target 'base-shell'
36
Makefile:298: warning: ignoring old recipe for target 'base-shell'
37
Makefile:305: warning: overriding recipe for target 'uname'
38
Makefile:298: warning: ignoring old recipe for target 'uname'
39
Makefile:305: warning: overriding recipe for target '-m'
40
Makefile:298: warning: ignoring old recipe for target '-m'
41
Makefile:305: warning: overriding recipe for target '|'
42
Makefile:298: warning: ignoring old recipe for target '|'
43
Makefile:305: warning: overriding recipe for target 'sed'
44
Makefile:298: warning: ignoring old recipe for target 'sed'
45
Makefile:305: warning: overriding recipe for target '-e'
46
Makefile:298: warning: ignoring old recipe for target '-e'
47
Makefile:305: warning: overriding recipe for target ''s/x86_64/amd64/''
48
Makefile:298: warning: ignoring old recipe for target ''s/x86_64/amd64/''
```
