### PR TITLE
Speed up dockcross entrypoint

### DIFF
--- a/imagefiles/entrypoint.sh
+++ b/imagefiles/entrypoint.sh
@@ -28,6 +28,9 @@ if [[ -n $BUILDER_UID ]] && [[ -n $BUILDER_GID ]]; then
     useradd -o -m -g "$BUILDER_GID" -u "$BUILDER_UID" "$BUILDER_USER" 2> /dev/null
     export HOME=/home/${BUILDER_USER}
     shopt -s dotglob
+    # Move rustup/cargo directories as they are large, and not needed as root
+    mv -t $HOME/ /root/.rustup /root/.cargo
+    # Copy the rest
     cp -r /root/* $HOME/
     chown -R $BUILDER_UID:$BUILDER_GID $HOME
 

--- a/imagefiles/entrypoint.sh
+++ b/imagefiles/entrypoint.sh
@@ -38,7 +38,7 @@ if [[ -n $BUILDER_UID ]] && [[ -n $BUILDER_GID ]]; then
 
     # Enable passwordless sudo capabilities for the user
     chown root:$BUILDER_GID "$(which gosu)"
-    chmod +s "$(which gosu)"; sync
+    chmod +s "$(which gosu)"
 
     # Execute project specific pre execution hook
     if [[ -e /work/.dockcross ]]; then


### PR DESCRIPTION
Partially fixes #886, see details there.

--

### imagefiles/entrypoint.sh: Move rust/cargo directories

Presumably we do not need those as root.

### imagefiles/entrypoint.sh: Remove sync call

This slows down the container startup for what appears to be no
good reason.

This workaround was added in 2016:
dd9d902538b350a7388525e786db99be10b4f6a5 ,
see also https://github.com/moby/moby/issues/13594#issuecomment-262441366 ,
and hopefully AUFS has been fixed by now.