### PR TITLE
fix(install-gosu-binary): Prefer checking key from server using "hkps" protocol

### DIFF
--- a/imagefiles/install-gosu-binary.sh
+++ b/imagefiles/install-gosu-binary.sh
@@ -56,6 +56,7 @@ url_key="https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$
 # download and verify the signature
 export GNUPGHOME="$(mktemp -d)"
 
+gpg --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 || \
 gpg --keyserver hkp://pool.sks-keyservers.net:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 || \
 gpg --keyserver hkp://pgp.key-server.io:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 || \
 gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4


### PR DESCRIPTION
The preferred server matches the official documentation. See https://github.com/tianon/gosu/blob/master/INSTALL.md

It was introduced upstream through https://github.com/tianon/gosu/commit/169711453c89322c6052c1c2eb6865818caae01b