### PR TITLE
Update Android SDK to 24

### DIFF
--- a/android-arm/Dockerfile.in
+++ b/android-arm/Dockerfile.in
@@ -18,7 +18,7 @@ ENV AS=${CROSS_ROOT}/bin/llvm-as \
     LD=${CROSS_ROOT}/bin/ld
 
 ENV ANDROID_NDK_REVISION=28b
-ENV ANDROID_API=23
+ENV ANDROID_API=24
 
 RUN mkdir -p /build && \
     cd /build && \

--- a/android-arm64/Dockerfile.in
+++ b/android-arm64/Dockerfile.in
@@ -22,7 +22,7 @@ ENV AS=${CROSS_ROOT}/bin/llvm-as \
     LD=${CROSS_ROOT}/bin/ld
 
 ENV ANDROID_NDK_REVISION=28b
-ENV ANDROID_API=23
+ENV ANDROID_API=24
 
 RUN mkdir -p /build && \
     cd /build && \

--- a/android-x86/Dockerfile
+++ b/android-x86/Dockerfile
@@ -12,7 +12,7 @@ ENV AS=${CROSS_ROOT}/bin/llvm-as \
     LD=${CROSS_ROOT}/bin/ld
 
 ENV ANDROID_NDK_REVISION=28b
-ENV ANDROID_API=23
+ENV ANDROID_API=24
 
 RUN mkdir -p /build && \
     cd /build && \

--- a/android-x86_64/Dockerfile
+++ b/android-x86_64/Dockerfile
@@ -12,7 +12,7 @@ ENV AS=${CROSS_ROOT}/bin/llvm-as \
     LD=${CROSS_ROOT}/bin/ld
 
 ENV ANDROID_NDK_REVISION=28b
-ENV ANDROID_API=23
+ENV ANDROID_API=24
 
 RUN mkdir -p /build && \
     cd /build && \


### PR DESCRIPTION
Following the [update to NDK r28b](https://github.com/dockcross/dockcross/pull/895), it makes sense to update the SDK to at least v24, because some features in the NDK now expect it.

I tested on a gstreamer build that failed with the latest dockcross image (android-arm) and builds successfully with this fix.

E.g. [seeko](https://android.googlesource.com/platform/bionic/+/master/libc/include/stdio.h#216) and [ftello](https://android.googlesource.com/platform/bionic/+/master/libc/include/stdio.h#217) require API 24 (see `__INTRODUCED_IN(24)`).