### PR TITLE
manylinux_2_28_x64: bump base to 2025.08.12-1

### DIFF
--- a/manylinux_2_28-x64/Dockerfile.in
+++ b/manylinux_2_28-x64/Dockerfile.in
@@ -1,5 +1,5 @@
 # Recent versions address yum functionality
-FROM quay.io/pypa/manylinux_2_28_x86_64:2025-02-15-d68c3fb
+FROM quay.io/pypa/manylinux_2_28_x86_64:2025.08.12-1
 
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"
 


### PR DESCRIPTION
Relatively recent image that passed container security checks.
