### PR TITLE
ci: push multi-arch images with manifest-tool

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1547,6 +1547,13 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
 
+      - name: Install manifest-tool
+        if: github.ref == 'refs/heads/master'
+        run: |
+          wget https://github.com/estesp/manifest-tool/releases/latest/download/binaries-manifest-tool.tar.gz -O - | tar -xz
+          sudo cp manifest-tool-linux-amd64 /usr/local/bin/manifest-tool
+          sudo chmod +x /usr/local/bin/manifest-tool
+
       - name: deploy-multi-arch
         if: github.ref == 'refs/heads/master'
         run: |

--- a/README.md
+++ b/README.md
@@ -620,6 +620,14 @@ Note that the architecture is now `aarch64` instead of `amd64`, so it runs nativ
 
 \-\--
 
+## Multi-architecture Image Creation
+
+For creating multi-architecture container images, this project uses [manifest-tool](https://github.com/estesp/manifest-tool) to create and manage manifest lists that combine platform-specific images into a single multi-platform reference. This allows container runtimes to automatically select the appropriate image based on the target architecture.
+
+The multi-architecture images are built on different architectures (amd64 and arm64) and then combined using manifest-tool's `push from-args` command, which creates manifest lists pointing to the individual platform-specific images.
+
+---
+
 Credits:
 
 - [sdt/docker-raspberry-pi-cross-compiler](https://github.com/sdt/docker-raspberry-pi-cross-compiler), who invented the base of the **dockcross** script.


### PR DESCRIPTION
Instead of buildah.

- Simplified workflow: manifest-tool provides a more straightforward command-line interface for creating manifest lists
- Better integration: manifest-tool is specifically designed for manifest list/OCI index creation and management
- Cross-platform compatibility: Works with both Docker v2.2 manifest lists and OCI v1 indexes
- Template-based approach: The --template and --platforms flags provide a cleaner way to specify multi-arch images
