### PR TITLE
Update debian version from bookworm to trixie

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,4 +1,4 @@
-ARG DOCKER_IMAGE=debian:bookworm-slim
+ARG DOCKER_IMAGE=debian:trixie-slim
 FROM $DOCKER_IMAGE
 
 LABEL maintainer="Matt McCormick matt@mmmccormick.com"


### PR DESCRIPTION
Looks like pretty straightforward change. Nevertheless some images may require additional changes. This update comes with newer python version, newer compilers, etc. which is quite useful in my dev environments. 